### PR TITLE
Revises apache_mods_enabled to use ansible module and allow override

### DIFF
--- a/defaults/Debian.yml
+++ b/defaults/Debian.yml
@@ -11,4 +11,4 @@ apache_packages:
 apache_vhosts:
   - {servername: "local.dev", documentroot: "/var/www"}
 apache_mods_enabled:
-  - rewrite.load
+  - rewrite

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -22,10 +22,7 @@
   }
   notify: restart apache
 
-- name: Enable Apache mods (Debian).
-  file: >
-    src={{ apache_server_root }}/mods-available/{{ item }}
-    dest={{ apache_server_root }}/mods-enabled/{{ item }}
-    state=link
+- name: Enable apache2 module
+  apache2_module: state=present name={{ item }}
   with_items: apache_mods_enabled
   notify: restart apache

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,5 +8,3 @@ apache_packages:
     - apache2-utils
     - apache2.2-bin
     - apache2.2-common
-apache_mods_enabled:
-  - rewrite.load


### PR DESCRIPTION
This should resolve the issue noted in #8 and updates to use ansible's apache2 module. I've only tested this on Ubuntu 12.04, so I'm not sure if this update also makes the task eligible for Redhat as well. If so it could be moved accordingly.
