### PR TITLE
Prevent task symlink vhost for Debian to failed.

### DIFF
--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -31,3 +31,4 @@
     src: "{{ apache_conf_path }}/sites-available/vhosts.conf"
     dest: "{{ apache_conf_path }}/sites-enabled/vhosts.conf"
     state: link
+  when: apache_create_vhosts


### PR DESCRIPTION
When vhost has not been created (using apache_create_vhosts: no), the
tasks should not be executed, otherwise it'll failed as the vhosts.conf
file has not been created and cannot been linked.
