### PR TITLE
Add virtual hosts with ssl to ssl.conf in RedHat based systems.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 apache_enablerepo: ""
 
 apache_listen_port: 80
+apache_listen_ssl_port: 443
 
 apache_mods_enabled:
   - rewrite.load

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -18,10 +18,20 @@
   notify: restart apache
   when: apache_create_vhosts
 
-- name: Add apache vhosts configuration.
+- name: Remove apache default ssl vhosts configuration.
   template:
     src: "ssl.conf.j2"
     dest: "{{ apache_conf_path }}/ssl.conf"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  when: apache_create_vhosts
+  
+- name: Remove apache default ssl vhosts configuration.
+  template:
+    src: "vhosts-ssl.conf.j2"
+    dest: "{{ apache_conf_path }}/vhosts-ssl.conf"
     owner: root
     group: root
     mode: 0644

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -17,3 +17,13 @@
     mode: 0644
   notify: restart apache
   when: apache_create_vhosts
+
+- name: Add apache vhosts configuration.
+  template:
+    src: "ssl.conf.j2"
+    dest: "{{ apache_conf_path }}/ssl.conf"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  when: apache_create_vhosts

--- a/templates/ssl.conf.j2
+++ b/templates/ssl.conf.j2
@@ -1,0 +1,102 @@
+#
+# This is the Apache server configuration file providing SSL support.
+# It contains the configuration directives to instruct the server how to
+# serve pages over an https connection. For detailing information about these
+# directives see <URL:http://httpd.apache.org/docs/2.2/mod/mod_ssl.html>
+#
+# Do NOT simply read the instructions in here without understanding
+# what they do.  They're here only as hints or reminders.  If you are unsure
+# consult the online docs. You have been warned.
+#
+
+LoadModule ssl_module modules/mod_ssl.so
+
+#
+# When we also provide SSL we have to listen to the
+# the HTTPS port in addition.
+#
+Listen 443
+
+##
+##  SSL Global Context
+##
+##  All SSL configuration in this context applies both to
+##  the main server and all SSL-enabled virtual hosts.
+##
+
+#   Pass Phrase Dialog:
+#   Configure the pass phrase gathering process.
+#   The filtering dialog program (`builtin' is a internal
+#   terminal dialog) has to provide the pass phrase on stdout.
+SSLPassPhraseDialog  builtin
+
+#   Inter-Process Session Cache:
+#   Configure the SSL Session Cache: First the mechanism
+#   to use and second the expiring timeout (in seconds).
+SSLSessionCache         shmcb:/var/cache/mod_ssl/scache(512000)
+SSLSessionCacheTimeout  300
+
+#   Semaphore:
+#   Configure the path to the mutual exclusion semaphore the
+#   SSL engine uses internally for inter-process synchronization.
+SSLMutex default
+
+#   Pseudo Random Number Generator (PRNG):
+#   Configure one or more sources to seed the PRNG of the
+#   SSL library. The seed data should be of good random quality.
+#   WARNING! On some platforms /dev/random blocks if not enough entropy
+#   is available. This means you then cannot use the /dev/random device
+#   because it would lead to very long connection times (as long as
+#   it requires to make more entropy available). But usually those
+#   platforms additionally provide a /dev/urandom device which doesn't
+#   block. So, if available, use this one instead. Read the mod_ssl User
+#   Manual for more details.
+SSLRandomSeed startup file:/dev/urandom  256
+SSLRandomSeed connect builtin
+#SSLRandomSeed startup file:/dev/random  512
+#SSLRandomSeed connect file:/dev/random  512
+#SSLRandomSeed connect file:/dev/urandom 512
+
+#
+# Use "SSLCryptoDevice" to enable any supported hardware
+# accelerators. Use "openssl engine -v" to list supported
+# engine names.  NOTE: If you enable an accelerator and the
+# server does not start, consult the error logs and ensure
+# your accelerator is functioning properly.
+#
+SSLCryptoDevice builtin
+#SSLCryptoDevice ubsec
+
+##
+## SSL Virtual Host Context
+##
+{% for vhost in apache_vhosts %}
+<VirtualHost *:{{ apache_listen_ssl_port }}>
+
+    ServerName {{ vhost.servername }}:{{ apache_listen_ssl_port }}
+    DocumentRoot {{ vhost.documentroot }}
+
+{% if vhost.serveradmin is defined %}
+    ServerAdmin {{ vhost.serveradmin }}
+{% endif %}
+
+    # Use separate log files for the SSL virtual host; note that LogLevel
+    # is not inherited from httpd.conf.
+    ErrorLog logs/ssl_error_log
+    TransferLog logs/ssl_access_log
+    LogLevel warn
+
+    SSLEngine on
+    SSLProtocol all -SSLv2
+    SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
+    SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+    SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+
+    SetEnvIf User-Agent ".*MSIE.*" \
+         nokeepalive ssl-unclean-shutdown \
+         downgrade-1.0 force-response-1.0
+
+         CustomLog logs/ssl_request_log \
+          "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+</VirtualHost>
+{% endfor %}

--- a/templates/ssl.conf.j2
+++ b/templates/ssl.conf.j2
@@ -15,7 +15,7 @@ LoadModule ssl_module modules/mod_ssl.so
 # When we also provide SSL we have to listen to the
 # the HTTPS port in addition.
 #
-Listen 443
+Listen {{ apache_listen_ssl_port }}
 
 ##
 ##  SSL Global Context
@@ -66,37 +66,3 @@ SSLRandomSeed connect builtin
 #
 SSLCryptoDevice builtin
 #SSLCryptoDevice ubsec
-
-##
-## SSL Virtual Host Context
-##
-{% for vhost in apache_vhosts %}
-<VirtualHost *:{{ apache_listen_ssl_port }}>
-
-    ServerName {{ vhost.servername }}:{{ apache_listen_ssl_port }}
-    DocumentRoot {{ vhost.documentroot }}
-
-{% if vhost.serveradmin is defined %}
-    ServerAdmin {{ vhost.serveradmin }}
-{% endif %}
-
-    # Use separate log files for the SSL virtual host; note that LogLevel
-    # is not inherited from httpd.conf.
-    ErrorLog logs/ssl_error_log
-    TransferLog logs/ssl_access_log
-    LogLevel warn
-
-    SSLEngine on
-    SSLProtocol all -SSLv2
-    SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
-    SSLCertificateFile /etc/pki/tls/certs/localhost.crt
-    SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
-
-    SetEnvIf User-Agent ".*MSIE.*" \
-         nokeepalive ssl-unclean-shutdown \
-         downgrade-1.0 force-response-1.0
-
-         CustomLog logs/ssl_request_log \
-          "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
-</VirtualHost>
-{% endfor %}

--- a/templates/vhosts-ssl.conf.j2
+++ b/templates/vhosts-ssl.conf.j2
@@ -1,0 +1,33 @@
+##
+## SSL Virtual Host Context
+##
+{% for vhost in apache_vhosts %}
+<VirtualHost *:{{ apache_listen_ssl_port }}>
+
+    ServerName {{ vhost.servername }}:{{ apache_listen_ssl_port }}
+    DocumentRoot {{ vhost.documentroot }}
+
+{% if vhost.serveradmin is defined %}
+    ServerAdmin {{ vhost.serveradmin }}
+{% endif %}
+
+    # Use separate log files for the SSL virtual host; note that LogLevel
+    # is not inherited from httpd.conf.
+    ErrorLog logs/ssl_error_log
+    TransferLog logs/ssl_access_log
+    LogLevel warn
+
+    SSLEngine on
+    SSLProtocol all -SSLv2
+    SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
+    SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+    SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+
+    SetEnvIf User-Agent ".*MSIE.*" \
+         nokeepalive ssl-unclean-shutdown \
+         downgrade-1.0 force-response-1.0
+
+         CustomLog logs/ssl_request_log \
+          "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+</VirtualHost>
+{% endfor %}


### PR DESCRIPTION
This is mostly a approach how SSL vhosts could be handled. There for it use the standard certificate shipped with apache in CentOs Apache.

templates/ssl.conf.j2 is based on the ssl.conf file. Only the Virtual host definition is handled by the template.