### PR TITLE
Made "vhost.conf" filename configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Other SSL directives can be managed with other SSL-related role variables.
 
 The SSL protocols and cipher suites that are used/allowed when clients make secure connections to your server. These are secure/sane defaults, but for maximum security, performand, and/or compatibility, you may need to adjust these settings.
 
+	apache_vhosts_filename: 'vhosts.conf'
+	
+The filename used for the vhost configuration.
+
     apache_mods_enabled:
       - rewrite.load
       - ssl.load

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,7 @@ apache_ssl_protocol: "All -SSLv2 -SSLv3"
 apache_ssl_cipher_suite: "AES256+EECDH:AES256+EDH"
 
 apache_vhosts_version: "2.2"
+apache_vhosts_filename: "vhosts.conf"
 
 apache_mods_enabled:
   - rewrite.load

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -19,7 +19,7 @@
 - name: Add apache vhosts configuration.
   template:
     src: "vhosts-{{ apache_vhosts_version }}.conf.j2"
-    dest: "{{ apache_conf_path }}/sites-available/vhosts.conf"
+    dest: "{{ apache_conf_path }}/sites-available/{{ apache_vhosts_filename }}"
     owner: root
     group: root
     mode: 0644
@@ -28,7 +28,7 @@
 
 - name: Add vhost symlink in sites-enabled.
   file:
-    src: "{{ apache_conf_path }}/sites-available/vhosts.conf"
-    dest: "{{ apache_conf_path }}/sites-enabled/vhosts.conf"
+    src: "{{ apache_conf_path }}/sites-available/{{ apache_vhosts_filename }}"
+    dest: "{{ apache_conf_path }}/sites-enabled/{{ apache_vhosts_filename }}"
     state: link
   when: apache_create_vhosts

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -11,7 +11,7 @@
 - name: Add apache vhosts configuration.
   template:
     src: "vhosts-{{ apache_vhosts_version }}.conf.j2"
-    dest: "{{ apache_conf_path }}/vhosts.conf"
+    dest: "{{ apache_conf_path }}/{{ apache_vhosts_filename }}"
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
I've made the vhost.conf filename configurable. This allows for setups where different playbooks are run on the same server (e.g. one playbook would use mysite1.conf and the other one mysite2.conf). Otherwise, each playbook overrides the other's vhost.conf.

In case you're wondering a use-case - Some of our sites are put on their own servers, some are grouped on to the same server. This allows us to have a separate playbook for each site, but run it on the same destination server. The advantage being that when a site grows too large for the server, we simply spin up a new server and change the inventory to that server.