### PR TITLE
Allowing the default vhost to be removed. Causes issues because it is li...

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ apache_enablerepo: ""
 apache_listen_port: 80
 apache_listen_port_ssl: 443
 
+apache_remove_default_vhost: false
 apache_create_vhosts: true
 apache_vhosts_filename: "vhosts.conf"
 

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -32,3 +32,9 @@
     dest: "{{ apache_conf_path }}/sites-enabled/{{ apache_vhosts_filename }}"
     state: link
   when: apache_create_vhosts
+  
+- name: Remove default vhost symlink in sites-enabled.
+  file:
+    path: "{{ apache_conf_path }}/sites-enabled/{{ apache_default_vhost_filename }}"
+    state: absent
+  when: apache_remove_default_vhost

--- a/vars/apache-22.yml
+++ b/vars/apache-22.yml
@@ -1,5 +1,6 @@
 ---
 apache_vhosts_version: "2.2"
+apache_default_vhost_filename: 000-default
 apache_ports_configuration_items:
   - {
     regexp: "^Listen ",

--- a/vars/apache-24.yml
+++ b/vars/apache-24.yml
@@ -1,5 +1,6 @@
 ---
 apache_vhosts_version: "2.4"
+apache_default_vhost_filename: 000-default.conf
 apache_ports_configuration_items:
   - {
     regexp: "^Listen ",


### PR DESCRIPTION
When you install Apache on Debian or Ubuntu a default vhost is installed in sites-enabled. Its name is either 000-default.conf or 000-default depending on the Apache version.

When you change **apache_listen_port**, the default vhost is still linked to port 80 which causes issues when reloading/restarting Apache.