### PR TITLE
Fix #25 Get installed version of Apache. failed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 
 # Figure out what version of Apache is installed.
 - name: Get installed version of Apache.
-  command: "{{ apache_daemon }} -v"
+  shell: "{{apache_daemon_path}}{{ apache_daemon }} -v"
   changed_when: false
   always_run: yes
   register: _apache_version

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,6 @@
 ---
 apache_daemon: apache2
+apache_daemon_path: /usr/sbin/
 apache_server_root: /etc/apache2
 apache_conf_path: /etc/apache2
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,6 @@
 ---
 apache_daemon: httpd
+apache_daemon_path: /usr/sbin/
 apache_server_root: /etc/httpd
 apache_conf_path: /etc/httpd/conf.d
 


### PR DESCRIPTION
Add absolute path for apache/httpd to avoid command not found error

For me this works on CentOS 6/7 and test via Travis on Ubuntu is stable