### PR TITLE
Added VirtualDocumentRoot to templates.

### DIFF
--- a/templates/vhosts-2.2.conf.j2
+++ b/templates/vhosts-2.2.conf.j2
@@ -8,12 +8,20 @@ DirectoryIndex index.php index.html
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
+{% if vhost.documentroot is defined %}
   DocumentRoot {{ vhost.documentroot }}
+{% elif vhost.virtualdocumentroot is defined %}
+  VirtualDocumentRoot {{ vhost.virtualdocumentroot }}
+{% endif %}
 
 {% if vhost.serveradmin is defined %}
   ServerAdmin {{ vhost.serveradmin }}
 {% endif %}
+{% if vhost.documentroot is defined %}
   <Directory "{{ vhost.documentroot }}">
+{% elif vhost.virtualdocumentroot is defined %}
+  <Directory "{{ vhost.directory }}">
+{% endif %}
     AllowOverride All
     Options -Indexes FollowSymLinks
     Order allow,deny
@@ -33,7 +41,11 @@ DirectoryIndex index.php index.html
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
+{% if vhost.documentroot is defined %}
   DocumentRoot {{ vhost.documentroot }}
+{% elif vhost.virtualdocumentroot is defined %}
+  VirtualDocumentRoot {{ vhost.virtualdocumentroot }}
+{% endif %}
 
   SSLEngine on
   SSLCipherSuite {{ apache_ssl_cipher_suite }}
@@ -48,7 +60,11 @@ DirectoryIndex index.php index.html
 {% if vhost.serveradmin is defined %}
   ServerAdmin {{ vhost.serveradmin }}
 {% endif %}
+{% if vhost.documentroot is defined %}
   <Directory "{{ vhost.documentroot }}">
+{% elif vhost.virtualdocumentroot is defined %}
+  <Directory "{{ vhost.directory }}">
+{% endif %}
     AllowOverride All
     Options -Indexes FollowSymLinks
     Order allow,deny

--- a/templates/vhosts-2.4.conf.j2
+++ b/templates/vhosts-2.4.conf.j2
@@ -8,12 +8,20 @@ DirectoryIndex index.php index.html
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
+{% if vhost.documentroot is defined %}
   DocumentRoot {{ vhost.documentroot }}
+{% elif vhost.virtualdocumentroot is defined %}
+  VirtualDocumentRoot {{ vhost.virtualdocumentroot }}
+{% endif %}
 
 {% if vhost.serveradmin is defined %}
   ServerAdmin {{ vhost.serveradmin }}
 {% endif %}
+{% if vhost.documentroot is defined %}
   <Directory "{{ vhost.documentroot }}">
+{% elif vhost.virtualdocumentroot is defined %}
+  <Directory "{{ vhost.directory }}">
+{% endif %}
     AllowOverride All
     Options -Indexes +FollowSymLinks
     Require all granted
@@ -32,7 +40,11 @@ DirectoryIndex index.php index.html
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
+{% if vhost.documentroot is defined %}
   DocumentRoot {{ vhost.documentroot }}
+{% elif vhost.virtualdocumentroot is defined %}
+  VirtualDocumentRoot {{ vhost.virtualdocumentroot }}
+{% endif %}
 
   SSLEngine on
   SSLCipherSuite {{ apache_ssl_cipher_suite }}
@@ -48,7 +60,11 @@ DirectoryIndex index.php index.html
 {% if vhost.serveradmin is defined %}
   ServerAdmin {{ vhost.serveradmin }}
 {% endif %}
+{% if vhost.documentroot is defined %}
   <Directory "{{ vhost.documentroot }}">
+{% elif vhost.virtualdocumentroot is defined %}
+  <Directory "{{ vhost.directory }}">
+{% endif %}
     AllowOverride All
     Options -Indexes +FollowSymLinks
     Require all granted


### PR DESCRIPTION
I added an option to use VirtualDocumentRoot, because I like to be able to add more sites without changing the Apache configuration. If a user doesn't want to use VirtualDocumentRoot, the configuration can be used as normal.

I want to use Drupal VM and would prefer to fork as little as possible.
