### PR TITLE
Replace ssl port listeners in ports.conf (Apache 2.4)

### DIFF
--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -1,10 +1,9 @@
 ---
 - name: Configure Apache.
-  lineinfile:
+  replace:
     dest: "{{ apache_server_root }}/ports.conf"
     regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-    state: present
+    replace: "{{ item.replace }}"
   with_items: apache_ports_configuration_items
   notify: restart apache
 

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -1,10 +1,9 @@
 ---
 - name: Configure Apache.
-  lineinfile:
+  replace:
     dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
     regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-    state: present
+    replace: "{{ item.replace }}"
   with_items: apache_ports_configuration_items
   notify: restart apache
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -11,6 +11,14 @@ __apache_packages:
 
 apache_ports_configuration_items:
   - {
-    regexp: "^Listen ",
-    line: "Listen {{ apache_listen_port }}"
+    regexp: "^Listen .*$",
+    replace: "Listen {{ apache_listen_port }}"
+  }
+  - {
+    regexp: "^<IfModule ssl_module>\n\tListen .*$",
+    replace: "<IfModule ssl_module>\n\tListen {{ apache_listen_port_ssl }}"
+  }
+  - {
+    regexp: "^<IfModule mod_gnutls.c>\n\tListen .*$",
+    replace: "<IfModule mod_gnutls.c>\n\tListen {{ apache_listen_port_ssl }}"
   }

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -14,10 +14,10 @@ __apache_packages:
 
 apache_ports_configuration_items:
   - {
-    regexp: "^Listen ",
-    line: "Listen {{ apache_listen_port }}"
+    regexp: "^Listen .*$",
+    replace: "Listen {{ apache_listen_port }}"
   }
   - {
-    regexp: "^NameVirtualHost ",
-    line: "NameVirtualHost *:{{ apache_listen_port }}"
+    regexp: "^NameVirtualHost .*$",
+    replace: "NameVirtualHost *:{{ apache_listen_port }}"
   }

--- a/vars/apache-22.yml
+++ b/vars/apache-22.yml
@@ -3,10 +3,10 @@ apache_vhosts_version: "2.2"
 apache_default_vhost_filename: 000-default
 apache_ports_configuration_items:
   - {
-    regexp: "^Listen ",
-    line: "Listen {{ apache_listen_port }}"
+    regexp: "^Listen .*$",
+    replace: "Listen {{ apache_listen_port }}"
   }
   - {
-    regexp: "^NameVirtualHost ",
-    line: "NameVirtualHost *:{{ apache_listen_port }}"
+    regexp: "^NameVirtualHost .*$",
+    replace: "NameVirtualHost *:{{ apache_listen_port }}"
   }

--- a/vars/apache-24.yml
+++ b/vars/apache-24.yml
@@ -3,6 +3,14 @@ apache_vhosts_version: "2.4"
 apache_default_vhost_filename: 000-default.conf
 apache_ports_configuration_items:
   - {
-    regexp: "^Listen ",
-    line: "Listen {{ apache_listen_port }}"
+    regexp: "^Listen .*$",
+    replace: "Listen {{ apache_listen_port }}"
+  }
+  - {
+    regexp: "^<IfModule ssl_module>\n\tListen .*$",
+    replace: "<IfModule ssl_module>\n\tListen {{ apache_listen_port_ssl }}"
+  }
+  - {
+    regexp: "^<IfModule mod_gnutls.c>\n\tListen .*$",
+    replace: "<IfModule mod_gnutls.c>\n\tListen {{ apache_listen_port_ssl }}"
   }


### PR DESCRIPTION
With Apache 2.4 on Ubuntu Trusty, the default ports.conf file looks like this:

```
# If you just change the port or add more ports here, you will likely also
# have to change the VirtualHost statement in
# /etc/apache2/sites-enabled/000-default.conf

Listen 80

<IfModule ssl_module>
    Listen 443
</IfModule>

<IfModule mod_gnutls.c>
    Listen 443
</IfModule>
```

The existing `lineinfile` task will only replace the first `Listen 80`, leaving the two `Listen 443` parts untouched. To replace both of them, with line-spanning regex support, I had to change `lineinfile` to `replace`.
