### PR TITLE
Made vhost.certificate_chain_file overridable

### DIFF
--- a/templates/vhosts-2.2.conf.j2
+++ b/templates/vhosts-2.2.conf.j2
@@ -41,7 +41,7 @@ DirectoryIndex index.php index.html
   SSLHonorCipherOrder On
   SSLCertificateFile {{ vhost.certificate_file }}
   SSLCertificateKeyFile {{ vhost.certificate_key_file }}
-{% if vhost.certificate_chain_file is defined %}
+{% if vhost.certificate_chain_file|default(False) %}
   SSLCertificateChainFile {{ vhost.certificate_chain_file }}
 {% endif %}
 

--- a/templates/vhosts-2.4.conf.j2
+++ b/templates/vhosts-2.4.conf.j2
@@ -41,7 +41,7 @@ DirectoryIndex index.php index.html
   SSLCompression off
   SSLCertificateFile {{ vhost.certificate_file }}
   SSLCertificateKeyFile {{ vhost.certificate_key_file }}
-{% if vhost.certificate_chain_file is defined %}
+{% if vhost.certificate_chain_file|default(False) %}
   SSLCertificateChainFile {{ vhost.certificate_chain_file }}
 {% endif %}
 


### PR DESCRIPTION
Hi.

Proposed approach allows having `vhost.certificate_chain_file` defined, but if it equals `False` - `SSLCertificateChainFile` will not be added.

For example:

``` yaml
# playbook.yml
vars:
  certificate_chain_file: False
  apache_vhosts_ssl:
    - servername:
      ...
      certificate_chain_file: {{ certificate_chain_file }}
```

So now we can override `certificate_chain_file` (`ansible-playbook --extra-vars="certificate_chain_file=/path/to/local/chain.pem`) to use local chain for test purposes.

---

This change not breaking BC.
