### PR TITLE
Leaves the NameVirtualHost in the same location in the file

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -15,5 +15,5 @@ __apache_packages:
 apache_ports_configuration_items:
   - regexp: "^Listen "
     line: "Listen {{ apache_listen_port }}"
-  - regexp: "^NameVirtualHost "
+  - regexp: "^#?NameVirtualHost "
     line: "NameVirtualHost *:{{ apache_listen_port }}"

--- a/vars/apache-22.yml
+++ b/vars/apache-22.yml
@@ -7,6 +7,6 @@ apache_ports_configuration_items:
     line: "Listen {{ apache_listen_port }}"
   }
   - {
-    regexp: "^NameVirtualHost ",
+    regexp: "^#?NameVirtualHost ",
     line: "NameVirtualHost *:{{ apache_listen_port }}"
   }


### PR DESCRIPTION
Currently the NameVirtualHost is placed at the end of the file, but the commented out #NameVirtualHost is left higher in the file.   This change leaves the configuration with its documentation by simply uncommenting the line.