### PR TITLE
Rename apache_global_settings to apache_global_vhosts_settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If set to true, a vhosts file, managed by this role's variables (see below), wil
 
 On Debian/Ubuntu, a default virtualhost is included in Apache's configuration. Set this to `true` to remove that default virtualhost configuration file.
 
-    apache_global_settings: |
+    apache_global_vhost_settings: |
       DirectoryIndex index.php index.html
       # Add other global settings on subsequent lines.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ apache_vhosts_filename: "vhosts.conf"
 # Set this to `true` to remove that default.
 apache_remove_default_vhost: false
 
-apache_global_settings: |
+apache_global_vhost_settings: |
   DirectoryIndex index.php index.html
 
 apache_vhosts:

--- a/templates/vhosts-2.2.conf.j2
+++ b/templates/vhosts-2.2.conf.j2
@@ -1,4 +1,4 @@
-{{ apache_global_vhosts_settings }}
+{{ apache_global_vhost_settings }}
 
 {# Set up VirtualHosts #}
 {% for vhost in apache_vhosts %}

--- a/templates/vhosts-2.2.conf.j2
+++ b/templates/vhosts-2.2.conf.j2
@@ -1,4 +1,4 @@
-{{ apache_global_settings }}
+{{ apache_global_vhosts_settings }}
 
 {# Set up VirtualHosts #}
 {% for vhost in apache_vhosts %}

--- a/templates/vhosts-2.4.conf.j2
+++ b/templates/vhosts-2.4.conf.j2
@@ -1,4 +1,4 @@
-{{ apache_global_settings }}
+{{ apache_global_vhost_settings }}
 
 {# Set up VirtualHosts #}
 {% for vhost in apache_vhosts %}


### PR DESCRIPTION
Related to the new variable created in PR #56, the name implies its in the apache httpd.conf file and not in each vhosts file.  This renames the variable to be clearer.