### PR TITLE
Run multi-platform tests on Travis-CI using Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,37 @@
----
-language: python
-python: "2.7"
-
+sudo: required
 env:
-  - SITE=test.yml
+  - CONTAINER_ID=$(mktemp)
+
+services:
+  - docker
 
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y curl
-
-install:
-  # Install Ansible.
-  - pip install ansible
-
-  # Add ansible.cfg to pick up roles path.
-  - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
+  - sudo apt-get update
+  # Pull containers
+  - sudo docker pull centos:7
+  - sudo docker pull ubuntu:14.04
+  # Customize containers
+  - sudo docker build --rm=true --file=Dockerfile.centos --tag=centos:ansible tests
+  - sudo docker build --rm=true --file=Dockerfile.ubuntu --tag=ubuntu:ansible tests
 
 script:
-  # Check the role/playbook's syntax.
-  - "ansible-playbook -i tests/inventory tests/$SITE --syntax-check"
+  #
+  # Run test playbook on Ubuntu container
+  #
+  - sudo docker run ubuntu:ansible ansible-playbook /etc/ansible/test.yml --syntax-check
+  - sudo docker run ubuntu:ansible ansible-playbook /etc/ansible/test.yml
 
-  # Run the role/playbook with ansible-playbook.
-  - "ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo"
+  #
+  # Run test playbook on CentOS container
+  #
 
-  # Run the role/playbook again, checking to make sure it's idempotent.
-  - >
-    ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo
-    | grep -q 'changed=0.*failed=0'
-    && (echo 'Idempotence test: pass' && exit 0)
-    || (echo 'Idempotence test: fail' && exit 1)
+  # Run container in detached state
+  - sudo docker run --detach --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro centos:ansible /usr/lib/systemd/systemd > "${CONTAINER_ID}"
 
-  # Request a page via Apache, to make sure Apache is running and responds.
-  - "curl http://localhost/"
+  - sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml --syntax-check
+  - sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml
+  # Clean up
+  - sudo docker stop "$(cat ${CONTAINER_ID})"
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
 sudo: required
 env:
-  - container_id=$(mktemp) distribution=centos version=7     init=/usr/lib/systemd/systemd
-  - container_id=$(mktemp) distribution=ubuntu version=14.04 init=/sbin/init
+  - >
+    container_id=$(mktemp)
+    distribution=centos
+    version=7
+    init=/usr/lib/systemd/systemd
+    run_opts="--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - >
+    container_id=$(mktemp)
+    distribution=ubuntu
+    version=14.04
+    init=/sbin/init
+    run_opts=""
 
 services:
   - docker
@@ -19,7 +29,7 @@ script:
   #
 
     # Run container in detached state
-  - sudo docker run --detach ${distribution}:ansible "${init}" > "${container_id}"
+  - sudo docker run --detach ${run_opts} ${distribution}:ansible "${init}" > "${container_id}"
 
     # Syntax check
   - sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/test.yml --syntax-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,62 +1,39 @@
 sudo: required
 env:
-  - CONTAINER_ID=$(mktemp)
+  - container_id=$(mktemp) distribution=centos version=7
+  - container_id=$(mktemp) distribution=ubuntu version=14.04
 
 services:
   - docker
 
 before_install:
   - sudo apt-get update
-  # Pull containers
-  - sudo docker pull centos:7
-  - sudo docker pull ubuntu:14.04
-  # Customize containers
-  - sudo docker build --rm=true --file=tests/Dockerfile.centos --tag=centos:ansible tests
-  - sudo docker build --rm=true --file=tests/Dockerfile.ubuntu --tag=ubuntu:ansible tests
+  # Pull container
+  - sudo docker pull ${distribution}:${version}
+  # Customize container
+  - sudo docker build --rm=true --file=tests/Dockerfile.${distribution} --tag=${distribution}:ansible tests
 
 script:
   #
-  # Run test playbook on Ubuntu container
+  # Run test playbook
   #
 
     # Run container in detached state
-  - sudo docker run --detach ubuntu:ansible /sbin/init > "${CONTAINER_ID}"
-
+  - sudo docker run --detach ${distribution}:ansible /sbin/init > "${container_id}"
 
     # Syntax check
-  - sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml --syntax-check
+  - sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/test.yml --syntax-check
     # Test role
-  - sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml
+  - sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/test.yml
     # Idempotence test
   - >
-    sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml
+    sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/test.yml
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
 
     # Clean up
-  - sudo docker stop "$(cat ${CONTAINER_ID})"
-
-  #
-  # Run test playbook on CentOS container
-  #
-
-    # Run container in detached state
-  - sudo docker run --detach --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro centos:ansible /usr/lib/systemd/systemd > "${CONTAINER_ID}"
-
-    # Syntax check
-  - sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml --syntax-check
-    # Test role
-  - sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml
-    # Idempotence test
-  - >
-    sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml
-    | grep -q 'changed=0.*failed=0'
-    && (echo 'Idempotence test: pass' && exit 0)
-    || (echo 'Idempotence test: fail' && exit 1)
-
-    # Clean up
-  - sudo docker stop "$(cat ${CONTAINER_ID})"
+  - sudo docker stop "$(cat ${container_id})"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
   - sudo docker pull centos:7
   - sudo docker pull ubuntu:14.04
   # Customize containers
-  - sudo docker build --rm=true --file=Dockerfile.centos --tag=centos:ansible tests
-  - sudo docker build --rm=true --file=Dockerfile.ubuntu --tag=ubuntu:ansible tests
+  - sudo docker build --rm=true --file=tests/Dockerfile.centos --tag=centos:ansible tests
+  - sudo docker build --rm=true --file=tests/Dockerfile.ubuntu --tag=ubuntu:ansible tests
 
 script:
   #

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,15 @@ script:
   #
 
     # Run container in detached state
-  - sudo docker run --detach ${run_opts} ${distribution}:ansible "${init}" > "${container_id}"
+  - sudo docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} ${distribution}:ansible "${init}" > "${container_id}"
 
     # Syntax check
-  - sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/test.yml --syntax-check
+  - sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check
     # Test role
-  - sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/test.yml
+  - sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml
     # Idempotence test
   - >
-    sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/test.yml
+    sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,23 @@ script:
   # Run test playbook on Ubuntu container
   #
 
+    # Run container in detached state
+  - sudo docker run --detach ubuntu:ansible /sbin/init > "${CONTAINER_ID}"
+
+
     # Syntax check
-  - sudo docker run ubuntu:ansible ansible-playbook /etc/ansible/test.yml --syntax-check
+  - sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml --syntax-check
     # Test role
-  - sudo docker run ubuntu:ansible ansible-playbook /etc/ansible/test.yml
+  - sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml
     # Idempotence test
   - >
-    sudo docker run ubuntu:ansible ansible-playbook /etc/ansible/test.yml
+    sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
+
+    # Clean up
+  - sudo docker stop "$(cat ${CONTAINER_ID})"
 
   #
   # Run test playbook on CentOS container

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,37 @@ script:
   #
   # Run test playbook on Ubuntu container
   #
+
+    # Syntax check
   - sudo docker run ubuntu:ansible ansible-playbook /etc/ansible/test.yml --syntax-check
+    # Test role
   - sudo docker run ubuntu:ansible ansible-playbook /etc/ansible/test.yml
+    # Idempotence test
+  - >
+    sudo docker run ubuntu:ansible ansible-playbook /etc/ansible/test.yml
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)
 
   #
   # Run test playbook on CentOS container
   #
 
-  # Run container in detached state
+    # Run container in detached state
   - sudo docker run --detach --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro centos:ansible /usr/lib/systemd/systemd > "${CONTAINER_ID}"
 
+    # Syntax check
   - sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml --syntax-check
+    # Test role
   - sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml
-  # Clean up
+    # Idempotence test
+  - >
+    sudo docker exec "$(cat ${CONTAINER_ID})" ansible-playbook /etc/ansible/test.yml
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)
+
+    # Clean up
   - sudo docker stop "$(cat ${CONTAINER_ID})"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 env:
-  - container_id=$(mktemp) distribution=centos version=7
-  - container_id=$(mktemp) distribution=ubuntu version=14.04
+  - container_id=$(mktemp) distribution=centos version=7     init=/usr/lib/systemd/systemd
+  - container_id=$(mktemp) distribution=ubuntu version=14.04 init=/sbin/init
 
 services:
   - docker
@@ -19,7 +19,7 @@ script:
   #
 
     # Run container in detached state
-  - sudo docker run --detach ${distribution}:ansible /sbin/init > "${container_id}"
+  - sudo docker run --detach ${distribution}:ansible "${init}" > "${container_id}"
 
     # Syntax check
   - sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/test.yml --syntax-check

--- a/tests/Dockerfile.centos
+++ b/tests/Dockerfile.centos
@@ -1,0 +1,26 @@
+FROM centos:7
+# Install systemd -- See https://hub.docker.com/_/centos/
+RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs
+RUN yum -y update; yum clean all; \
+(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*; \
+rm -f /etc/systemd/system/*.wants/*; \
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*; \
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+# Install Ansible
+RUN yum -y install epel-release
+RUN yum -y install git ansible sudo
+RUN yum clean all
+# Disable requiretty
+RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
+# Install Ansible inventory file
+RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+COPY requirements.yml /etc/ansible/requirements.yml
+COPY test.yml /etc/ansible/test.yml
+RUN ansible-galaxy install -r /etc/ansible/requirements.yml
+VOLUME [ "/sys/fs/cgroup" ]
+CMD ["/usr/sbin/init"]
+

--- a/tests/Dockerfile.centos
+++ b/tests/Dockerfile.centos
@@ -18,9 +18,6 @@ RUN yum clean all
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 # Install Ansible inventory file
 RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
-COPY requirements.yml /etc/ansible/requirements.yml
-RUN ansible-galaxy install -r /etc/ansible/requirements.yml
-COPY test.yml /etc/ansible/test.yml
 VOLUME [ "/sys/fs/cgroup" ]
 CMD ["/usr/sbin/init"]
 

--- a/tests/Dockerfile.centos
+++ b/tests/Dockerfile.centos
@@ -19,8 +19,8 @@ RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 # Install Ansible inventory file
 RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 COPY requirements.yml /etc/ansible/requirements.yml
-COPY test.yml /etc/ansible/test.yml
 RUN ansible-galaxy install -r /etc/ansible/requirements.yml
+COPY test.yml /etc/ansible/test.yml
 VOLUME [ "/sys/fs/cgroup" ]
 CMD ["/usr/sbin/init"]
 

--- a/tests/Dockerfile.ubuntu
+++ b/tests/Dockerfile.ubuntu
@@ -1,0 +1,12 @@
+FROM ubuntu:14.04
+# Install Ansible
+RUN apt-get install -y software-properties-common git
+RUN apt-add-repository -y ppa:ansible/ansible
+RUN apt-get update
+RUN apt-get install -y ansible
+# Install Ansible inventory file
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+COPY requirements.yml /etc/ansible/requirements.yml
+COPY test.yml /etc/ansible/test.yml
+RUN ansible-galaxy install -r /etc/ansible/requirements.yml
+

--- a/tests/Dockerfile.ubuntu
+++ b/tests/Dockerfile.ubuntu
@@ -7,6 +7,6 @@ RUN apt-get install -y ansible
 # Install Ansible inventory file
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 COPY requirements.yml /etc/ansible/requirements.yml
-COPY test.yml /etc/ansible/test.yml
 RUN ansible-galaxy install -r /etc/ansible/requirements.yml
+COPY test.yml /etc/ansible/test.yml
 

--- a/tests/Dockerfile.ubuntu
+++ b/tests/Dockerfile.ubuntu
@@ -6,7 +6,4 @@ RUN apt-get update
 RUN apt-get install -y ansible
 # Install Ansible inventory file
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
-COPY requirements.yml /etc/ansible/requirements.yml
-RUN ansible-galaxy install -r /etc/ansible/requirements.yml
-COPY test.yml /etc/ansible/test.yml
 

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,1 @@
+- src: geerlingguy.apache

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,1 +1,0 @@
-- src: geerlingguy.apache

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,4 @@
 ---
-- hosts: localhost
-  remote_user: root
+- hosts: all
   roles:
-    - ansible-role-apache
+    - geerlingguy.apache

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,4 +1,11 @@
 ---
 - hosts: all
+  vars:
+    apache_listen_port_ssl: 443
+    apache_create_vhosts: true
+    apache_vhosts_filename: "vhosts.conf"
+    apache_vhosts:
+      - servername: "example.com"
+        documentroot: "/var/www/vhosts/example_com"
   roles:
     - geerlingguy.apache

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -8,4 +8,4 @@
       - servername: "example.com"
         documentroot: "/var/www/vhosts/example_com"
   roles:
-    - geerlingguy.apache
+    - role_under_test


### PR DESCRIPTION
This PR replaces the current test configuration for Travis-CI with a new one that will create a Docker container for CentOS and Ubuntu, and run the test playbook on each one. For an example of the result, see <https://travis-ci.org/bertvv/ansible-role-apache/builds/96439547>

What could be added is running black box system/acceptance tests from the host system (i.e. the Travis-CI VM), e.g. trying to access the website that runs on the container with `curl`. This is left as an exercise to the upstream maintainer... ;-)