### PR TITLE
Enabling the configuration of envvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,30 @@ The list of packages to be installed. This defaults to a set of platform-specifi
 
 Set initial Apache daemon state to be enforced when this role is run. This should generally remain `started`, but you can set it to `stopped` if you need to fix the Apache config during a playbook run or otherwise would not like Apache started at the time this role is run.
 
+(Debian/Ubuntu ONLY) You can edit the enviroment variables in `envvars`, to do that you must change `apache_create_envvars` to true, so the task run. 
+The following Variables (and the default value) are currently available:
+    
+    apache_envvars_multiple_instances_suffix: "-${APACHE_CONFDIR##/etc/apache2-}"
+    apache_envvars_run_user: www-data
+    apache_envvars_run_group: www-data
+    apache_envvars_pid_file: /var/run/apache2/apache2$SUFFIX.pid
+    apache_envvars_run_dir: /var/run/apache2$SUFFIX
+    apache_envvars_lock_dir: /var/lock/apache2$SUFFIX
+    apache_envvars_log_dir: /var/log/apache2$SUFFIX
+
+`APACHE_LYNX`, `APACHE_ULIMIT_MAX_FILES`, `APACHE_ARGUMENTS`, `APACHE2_MAINTSCRIPT_DEBUG` need to be activated before the value is added to the file.
+    
+    apache_envvars_lynx_enable: false
+    apache_envvars_lynx: 'www-browser -dump'
+    apache_envvars_ulimit_enable: false
+    apache_envvars_ulimit: 'ulimit -n 65536'
+    apache_envvars_arguments_enable: false
+    apache_envvars_arguments: ""
+    apache_envvars_maintscript_debug_enable: false
+    apache_envvars_maintscript_debug: 1
+
+the default values are stored in `vars/Debian.yml`
+
 ## Dependencies
 
 None.

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -33,6 +33,16 @@
   notify: restart apache
   when: apache_create_vhosts
 
+- name: Add apache envvars.
+  template:
+    src: "envvars.conf.j2"
+    dest: "{{ apache_conf_path }}/envvars"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  when: apache_create_envvars
+
 - name: Add vhost symlink in sites-enabled.
   file:
     src: "{{ apache_conf_path }}/sites-available/{{ apache_vhosts_filename }}"

--- a/templates/envvars.conf.j2
+++ b/templates/envvars.conf.j2
@@ -1,0 +1,55 @@
+# envvars - default environment variables for apache2ctl
+
+# this won't be correct after changing uid
+unset HOME
+
+# for supporting multiple apache2 instances
+if [ "${APACHE_CONFDIR##/etc/apache2-}" != "${APACHE_CONFDIR}" ] ; then
+SUFFIX={{ apache_envvars_multiple_instances_suffix }}
+else
+SUFFIX=
+fi
+
+# Since there is no sane way to get the parsed apache2 config in scripts, some
+# settings are defined via environment variables and then used in apache2ctl,
+# /etc/init.d/apache2, /etc/logrotate.d/apache2, etc.
+export APACHE_RUN_USER={{ apache_envvars_run_user }}
+export APACHE_RUN_GROUP={{ apache_envvars_run_group }}
+# temporary state file location. This might be changed to /run in Wheezy+1
+export APACHE_PID_FILE={{ apache_envvars_pid_file }}
+export APACHE_RUN_DIR={{ apache_envvars_run_dir }}
+export APACHE_LOCK_DIR={{ apache_envvars_lock_dir }}
+# Only /var/log/apache2 is handled by /etc/logrotate.d/apache2.
+export APACHE_LOG_DIR={{ apache_envvars_log_dir }}
+
+## The locale used by some modules like mod_dav
+export LANG=C
+## Uncomment the following line to use the system default locale instead:
+#. /etc/default/locale
+
+export LANG
+
+{% if apache_envvars_lynx_enable %}
+## The command to get the status for 'apache2ctl status'.
+## Some packages providing 'www-browser' need '--dump' instead of '-dump'.
+export APACHE_LYNX={{ apache_envvars_lynx }}
+{% endif %}
+
+{% if apache_envvars_lynx_enable %}
+## If you need a higher file descriptor limit, uncomment and adjust the
+## following line (default is 8192):
+APACHE_ULIMIT_MAX_FILES= {{ apache_envvars_ulimit }}
+{% endif %}
+
+{% if apache_envvars_arguments_enable %}
+## If you would like to pass arguments to the web server, add them below
+## to the APACHE_ARGUMENTS environment.
+export APACHE_ARGUMENTS={{ apache_envvars_arguments }}
+{% endif %}
+
+{% if apache_envvars_maintscript_debug_enable %}
+## Enable the debug mode for maintainer scripts.
+## This will produce a verbose output on package installations of web server modules and web application
+## installations which interact with Apache
+export APACHE2_MAINTSCRIPT_DEBUG={{ apache_envvars_maintscript_debug }}
+{% endif %}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -11,3 +11,22 @@ __apache_packages:
 apache_ports_configuration_items:
   - regexp: "^Listen "
     line: "Listen {{ apache_listen_port }}"
+
+# Set to true to manipulate the envvars
+apache_create_envvars: false
+
+apache_envvars_multiple_instances_suffix: "-${APACHE_CONFDIR##/etc/apache2-}"
+apache_envvars_run_user: www-data
+apache_envvars_run_group: www-data
+apache_envvars_pid_file: /var/run/apache2/apache2$SUFFIX.pid
+apache_envvars_run_dir: /var/run/apache2$SUFFIX
+apache_envvars_lock_dir: /var/lock/apache2$SUFFIX
+apache_envvars_log_dir: /var/log/apache2$SUFFIX
+apache_envvars_lynx_enable: false
+apache_envvars_lynx: 'www-browser -dump'
+apache_envvars_ulimit_enable: false
+apache_envvars_ulimit: 'ulimit -n 65536'
+apache_envvars_arguments_enable: false
+apache_envvars_arguments: ""
+apache_envvars_maintscript_debug_enable: false
+apache_envvars_maintscript_debug: 1


### PR DESCRIPTION
i have added support to change the envvars so you can change for example the Apache_run_user.

I have no idea if the configuration for RedHat Servers are the same so i tested and implemented this feature only for Debian Systems.