### PR TITLE
Set and unset only specified lines in ports.conf

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -10,5 +10,5 @@ __apache_packages:
   - apache2-utils
 
 apache_ports_configuration_items:
-  - regexp: "^Listen "
+  - regexp: "^Listen {{ apache_listen_port }}$"
     line: "Listen {{ apache_listen_port }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -16,5 +16,5 @@ __apache_packages:
 apache_ports_configuration_items:
   - regexp: "^Listen {{ apache_listen_port }}$"
     line: "Listen {{ apache_listen_port }}"
-  - regexp: "^#?NameVirtualHost *:{{ apache_listen_port }}$"
+  - regexp: "^#?NameVirtualHost \\*:{{ apache_listen_port }}$"
     line: "NameVirtualHost *:{{ apache_listen_port }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -14,7 +14,7 @@ __apache_packages:
   - openssh
 
 apache_ports_configuration_items:
-  - regexp: "^Listen "
+  - regexp: "^Listen {{ apache_listen_port }}$"
     line: "Listen {{ apache_listen_port }}"
-  - regexp: "^#?NameVirtualHost "
+  - regexp: "^#?NameVirtualHost *:{{ apache_listen_port }}$"
     line: "NameVirtualHost *:{{ apache_listen_port }}"

--- a/vars/Solaris.yml
+++ b/vars/Solaris.yml
@@ -13,7 +13,7 @@ __apache_packages:
   - web/server/apache-24/module/apache-security
 
 apache_ports_configuration_items:
-  - regexp: "^Listen "
+  - regexp: "^Listen {{ apache_listen_port }}$"
     line: "Listen {{ apache_listen_port }}"
-  - regexp: "^#?NameVirtualHost "
+  - regexp: "^NameVirtualHost \\*:{{ apache_listen_port }}$"
     line: "NameVirtualHost *:{{ apache_listen_port }}"

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -12,7 +12,7 @@ __apache_packages:
   - openssh
 
 apache_ports_configuration_items:
-  - regexp: "^Listen "
+  - regexp: "^Listen {{ apache_listen_port }}$"
     line: "Listen {{ apache_listen_port }}"
-  - regexp: "^#?NameVirtualHost "
+  - regexp: "^NameVirtualHost \\*:{{ apache_listen_port }}$"
     line: "NameVirtualHost *:{{ apache_listen_port }}"

--- a/vars/apache-22.yml
+++ b/vars/apache-22.yml
@@ -3,10 +3,10 @@ apache_vhosts_version: "2.2"
 apache_default_vhost_filename: 000-default
 apache_ports_configuration_items:
   - {
-    regexp: "^Listen ",
+    regexp: "^Listen {{ apache_listen_port }}$",
     line: "Listen {{ apache_listen_port }}"
   }
   - {
-    regexp: "^#?NameVirtualHost ",
+    regexp: "^#?NameVirtualHost *:{{ apache_listen_port }}",
     line: "NameVirtualHost *:{{ apache_listen_port }}"
   }

--- a/vars/apache-22.yml
+++ b/vars/apache-22.yml
@@ -7,6 +7,6 @@ apache_ports_configuration_items:
     line: "Listen {{ apache_listen_port }}"
   }
   - {
-    regexp: "^#?NameVirtualHost *:{{ apache_listen_port }}",
+    regexp: "^#?NameVirtualHost \\*:{{ apache_listen_port }}$",
     line: "NameVirtualHost *:{{ apache_listen_port }}"
   }

--- a/vars/apache-24.yml
+++ b/vars/apache-24.yml
@@ -3,6 +3,6 @@ apache_vhosts_version: "2.4"
 apache_default_vhost_filename: 000-default.conf
 apache_ports_configuration_items:
   - {
-    regexp: "^Listen ",
+    regexp: "^Listen {{ apache_listen_port }}$",
     line: "Listen {{ apache_listen_port }}"
   }


### PR DESCRIPTION
Fixes #43 in limited cases

We have more than one vhost being controlled by this role, in different plays on the same host.  This would result in clobbering ports set in other runs, each time a play was run.

This change limits adding or removing a line in ports.conf to just the port set in apache_listen_port.  We aren't using ssl ports, so I'm 

Similar changes could be made for solaris and suse, but I haven't tested against them.
