### PR TITLE
Allow to disable HTTP(S) in Debian

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,9 @@ apache_enablerepo: ""
 
 apache_listen_port: 80
 apache_listen_port_ssl: 443
+apache_listen_ports:
+ - "{{ apache_listen_port }}"
+ - "{{ apache_listen_port_ssl }}"
 
 apache_create_vhosts: true
 apache_vhosts_filename: "vhosts.conf"

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -1,11 +1,8 @@
 ---
 - name: Configure Apache.
-  lineinfile:
+  template:
+    src: ports.conf
     dest: "{{ apache_server_root }}/ports.conf"
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-    state: present
-  with_items: apache_ports_configuration_items
   notify: restart apache
 
 - name: Enable Apache mods.

--- a/templates/ports.conf
+++ b/templates/ports.conf
@@ -1,0 +1,3 @@
+{% for port in apache_listen_ports %}
+Listen {{ port }}
+{% endfor %}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,7 +8,3 @@ apache_conf_path: /etc/apache2
 __apache_packages:
   - apache2
   - apache2-utils
-
-apache_ports_configuration_items:
-  - regexp: "^Listen "
-    line: "Listen {{ apache_listen_port }}"


### PR DESCRIPTION
I think the best way to do it, is to include a (OS-specific) template.
