### PR TITLE
Add configuration for listen address

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 apache_enablerepo: ""
 
+apache_listen_ip: "*"
 apache_listen_port: 80
 apache_listen_port_ssl: 443
 

--- a/templates/vhosts-2.2.conf.j2
+++ b/templates/vhosts-2.2.conf.j2
@@ -2,7 +2,7 @@
 
 {# Set up VirtualHosts #}
 {% for vhost in apache_vhosts %}
-<VirtualHost *:{{ apache_listen_port }}>
+<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
   ServerName {{ vhost.servername }}
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}
@@ -31,7 +31,7 @@
 
 {# Set up SSL VirtualHosts. #}
 {% for vhost in apache_vhosts_ssl %}
-<VirtualHost *:{{ apache_listen_port_ssl }}>
+<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port_ssl }}>
   ServerName {{ vhost.servername }}
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}

--- a/templates/vhosts-2.4.conf.j2
+++ b/templates/vhosts-2.4.conf.j2
@@ -2,7 +2,7 @@
 
 {# Set up VirtualHosts #}
 {% for vhost in apache_vhosts %}
-<VirtualHost *:{{ apache_listen_port }}>
+<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
   ServerName {{ vhost.servername }}
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}
@@ -31,7 +31,7 @@
 {# Set up SSL VirtualHosts #}
 {% for vhost in apache_vhosts_ssl %}
 {% if apache_ignore_missing_ssl_certificate or apache_ssl_certificates.results[loop.index0].stat.exists %}
-<VirtualHost *:{{ apache_listen_port_ssl }}>
+<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port_ssl }}>
   ServerName {{ vhost.servername }}
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -17,4 +17,4 @@ apache_ports_configuration_items:
   - regexp: "^Listen "
     line: "Listen {{ apache_listen_port }}"
   - regexp: "^#?NameVirtualHost "
-    line: "NameVirtualHost *:{{ apache_listen_port }}"
+    line: "NameVirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}"

--- a/vars/Solaris.yml
+++ b/vars/Solaris.yml
@@ -16,4 +16,4 @@ apache_ports_configuration_items:
   - regexp: "^Listen "
     line: "Listen {{ apache_listen_port }}"
   - regexp: "^#?NameVirtualHost "
-    line: "NameVirtualHost *:{{ apache_listen_port }}"
+    line: "NameVirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}"

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -15,4 +15,4 @@ apache_ports_configuration_items:
   - regexp: "^Listen "
     line: "Listen {{ apache_listen_port }}"
   - regexp: "^#?NameVirtualHost "
-    line: "NameVirtualHost *:{{ apache_listen_port }}"
+    line: "NameVirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}"

--- a/vars/apache-22.yml
+++ b/vars/apache-22.yml
@@ -8,5 +8,5 @@ apache_ports_configuration_items:
   }
   - {
     regexp: "^#?NameVirtualHost ",
-    line: "NameVirtualHost *:{{ apache_listen_port }}"
+    line: "NameVirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}"
   }


### PR DESCRIPTION
By default I leave it as "*", but for many cases, we don't want to bind our
apache to all network addresses available for the server. For example if we
want to only bind the apache to the localhost, we can use the following
configuration:

    apache_listen_ip: "127.0.0.1"