### PR TITLE
Make "AllowOverride" and "Options" configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can add or override global Apache configuration settings in the role-provide
       - servername: "local.dev"
         documentroot: "/var/www/html"
 
-Add a set of properties per virtualhost, including `servername` (required), `documentroot` (required), `serveradmin` (optional), `serveralias` (optional) and `extra_parameters` (optional: you can add whatever additional configuration lines you'd like in here).
+Add a set of properties per virtualhost, including `servername` (required), `documentroot` (required), `allow_override` (optional: defaults to the value of `apache_allow_override`), `options` (optional: defaults to the value of `apache_options`), `serveradmin` (optional), `serveralias` (optional) and `extra_parameters` (optional: you can add whatever additional configuration lines you'd like in here).
 
 Here's an example using `extra_parameters` to add a RewriteRule to redirect all requests to the `www.` site:
 
@@ -76,6 +76,11 @@ Other SSL directives can be managed with other SSL-related role variables.
     apache_ssl_cipher_suite: "AES256+EECDH:AES256+EDH"
 
 The SSL protocols and cipher suites that are used/allowed when clients make secure connections to your server. These are secure/sane defaults, but for maximum security, performand, and/or compatibility, you may need to adjust these settings.
+
+    apache_allow_override: "All"
+    apache_options: "-Indexes +FollowSymLinks"
+
+The default values for the `AllowOverride` and `Options` directives for the `documentroot` directory of each vhost.  A vhost can overwrite these values by specifying `allow_override` or `options`.
 
     apache_mods_enabled:
       - rewrite.load

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,12 +16,17 @@ apache_global_vhost_settings: |
   DirectoryIndex index.php index.html
 
 apache_vhosts:
-  # Additional properties: 'serveradmin, serveralias, extra_parameters'.
+  # Additional properties:
+  # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
   - servername: "local.dev"
     documentroot: "/var/www/html"
 
+apache_allow_override: "All"
+apache_options: "-Indexes +FollowSymLinks"
+
 apache_vhosts_ssl: []
-  # Additional properties: 'serveradmin, extra_parameters'.
+  # Additional properties:
+  # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
   # - servername: "local.dev",
   #   documentroot: "/var/www/html",
   #   certificate_file: "/path/to/certificate.crt",

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -16,8 +16,8 @@
 {% endif %}
 {% if vhost.documentroot is defined %}
   <Directory "{{ vhost.documentroot }}">
-    AllowOverride All
-    Options -Indexes +FollowSymLinks
+    AllowOverride {{ vhost.allow_override | default(apache_allow_override) }}
+    Options {{ vhost.options | default(apache_options) }}
 {% if apache_vhosts_version == "2.2" %}
     Order allow,deny
     Allow from all
@@ -63,8 +63,8 @@
 {% endif %}
 {% if vhost.documentroot is defined %}
   <Directory "{{ vhost.documentroot }}">
-    AllowOverride All
-    Options -Indexes +FollowSymLinks
+    AllowOverride {{ vhost.allow_override | default(apache_allow_override) }}
+    Options {{ vhost.options | default(apache_options) }}
 {% if apache_vhosts_version == "2.2" %}
     Order allow,deny
     Allow from all


### PR DESCRIPTION
This commit allows the user to change the `AllowOverride` and `Options` directives of the documentroot directory for different vhosts.

The default values are `AllowOverride All` and `Options -Indexes +FollowSymLinks` (see defaults/main.yml), so this commit is fully backwards compatible.

This feature was necessary for a use case of mine where I needed one vhost with indexing turned on.
