### PR TITLE
Install libselinux-python package when RHEL

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,4 +1,9 @@
 ---
+- name: Ensure libselinux-python is installed on RHEL.
+  yum:
+    name: "libselinux-python"
+    state: installed
+
 - name: Ensure Apache is installed on RHEL.
   yum:
     name: "{{ item }}"


### PR DESCRIPTION
When executing task "Add apache vhosts configuration."
on RHEL, if 'libselinux-python' package is not installed,
then the whole task will fail with the following msg:
"Aborting, target uses selinux but python bindings
(libselinux-python) aren't installed!".
To avoid this, ensure we install 'libselinux-python' pkg 
_before_ the Apache Vhost task is executed.
