### PR TITLE
Enhance apache restart handler to allow optional reloading

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,3 +42,6 @@ apache_mods_disabled: []
 
 # Set initial apache state. Recommended values: `started` or `stopped`
 apache_state: started
+
+# Set apache state when configuration changes are made. Recommended values: `restarted` or `reloaded`
+apache_restart_state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,4 +2,4 @@
 - name: restart apache
   service:
     name: "{{ apache_service }}"
-    state: restarted
+    state: "{{ apache_restart_state }}"


### PR DESCRIPTION
It is potentially safer to attempt to reload apache whenever there are configuration changes rather than restarting the service especially if the service isn't capable of being pulled out of active use before making changes.  This change is intended to give the user the ability to choose whether to reload configuration or restart the service when the restart handler is notified.
