### PR TITLE
Added support for custom Options in vhosts.conf Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,18 @@ On Debian/Ubuntu, a default virtualhost is included in Apache's configuration. S
 You can add or override global Apache configuration settings in the role-provided vhosts file (assuming `apache_create_vhosts` is true) using this variable. By default it only sets the DirectoryIndex configuration.
 
     apache_vhosts:
-      # Additional optional properties: 'serveradmin, serveralias, extra_parameters'.
+      # Additional optional properties: 'serveradmin, serveralias, extra_parameters, options'.
       - servername: "local.dev"
         documentroot: "/var/www/html"
 
-Add a set of properties per virtualhost, including `servername` (required), `documentroot` (required), `serveradmin` (optional), `serveralias` (optional) and `extra_parameters` (optional: you can add whatever additional configuration lines you'd like in here).
+Add a set of properties per virtualhost, including `servername` (required), `documentroot` (required), `serveradmin` (optional), `serveralias` (optional), `options` (optional) and `extra_parameters` (optional: you can add whatever additional configuration lines you'd like in here).
 
 Here's an example using `extra_parameters` to add a RewriteRule to redirect all requests to the `www.` site:
 
       - servername: "www.local.dev"
         serveralias: "local.dev"
         documentroot: "/var/www/html"
+        options: "-Indexes +FollowSymLinks"
         extra_parameters: |
           RewriteCond %{HTTP_HOST} !^www\. [NC]
           RewriteRule ^(.*)$ http://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -17,7 +17,11 @@
 {% if vhost.documentroot is defined %}
   <Directory "{{ vhost.documentroot }}">
     AllowOverride All
+{% if vhost.options is defined %}
+    Options {{ vhost.options }}
+{% else %}
     Options -Indexes +FollowSymLinks
+{% endif %}
 {% if apache_vhosts_version == "2.2" %}
     Order allow,deny
     Allow from all
@@ -64,7 +68,11 @@
 {% if vhost.documentroot is defined %}
   <Directory "{{ vhost.documentroot }}">
     AllowOverride All
+{% if vhost.options is defined %}
+    Options {{ vhost.options }}
+{% else %}
     Options -Indexes +FollowSymLinks
+{% endif %}
 {% if apache_vhosts_version == "2.2" %}
     Order allow,deny
     Allow from all


### PR DESCRIPTION
Sometimes the Options of `-Indexes +FollowSymLinks` aren't appropriate for a vhost directory. This patch adds an optional `options` property to the apache_vhost dictionary which lets you provide an different value for Options. If you don't provide an `options` property, the property defaults to `-Indexes +FollowSymLinks` as it was previously.
