### PR TITLE
#100 Add support for Alias

### DIFF
--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -7,6 +7,9 @@
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
+{% if vhost.alias is defined %}
+  Alias {{ vhost.alias }}
+{% endif %}
 {% if vhost.documentroot is defined %}
   DocumentRoot {{ vhost.documentroot }}
 {% endif %}
@@ -40,6 +43,9 @@
   ServerName {{ vhost.servername }}
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}
+{% endif %}
+{% if vhost.alias is defined %}
+  Alias {{ vhost.alias }}
 {% endif %}
 {% if vhost.documentroot is defined %}
   DocumentRoot {{ vhost.documentroot }}


### PR DESCRIPTION
https://github.com/geerlingguy/ansible-role-apache/issues/100

Besides from having a serveralias can we also support alias?

Something like

{# Set up VirtualHosts #}
{% for vhost in apache_vhosts %}
<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
  ServerName {{ vhost.servername }}
{% if vhost.serveralias is defined %}
  ServerAlias {{ vhost.serveralias }}
{% endif %}
{% if vhost.alias is defined %}
  Alias {{ vhost.alias }}
{% endif %}
{% if vhost.documentroot is defined %}
  DocumentRoot {{ vhost.documentroot }}
{% endif %}
Seems like this is a must have support for sub directory based multisite.

Using https://github.com/geerlingguy/drupal-vm with mutisite setup with different servername works fine, much better if this can also support sub directory based multisite.

Thanks!