### PR TITLE
make template file configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ apache_listen_port_ssl: 443
 
 apache_create_vhosts: true
 apache_vhosts_filename: "vhosts.conf"
+apache_vhosts_template: "vhosts.conf.j2"
 
 # On Debian/Ubuntu, a default virtualhost is included in Apache's configuration.
 # Set this to `true` to remove that default.

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -30,7 +30,7 @@
 
 - name: Add apache vhosts configuration.
   template:
-    src: "vhosts.conf.j2"
+    src: "{{ apache_vhosts_template }}"
     dest: "{{ apache_conf_path }}/sites-available/{{ apache_vhosts_filename }}"
     owner: root
     group: root

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -15,7 +15,7 @@
 
 - name: Add apache vhosts configuration.
   template:
-    src: "vhosts.conf.j2"
+    src: "{{ apache_vhosts_template }}"
     dest: "{{ apache_conf_path }}/{{ apache_vhosts_filename }}"
     owner: root
     group: root

--- a/tasks/configure-Solaris.yml
+++ b/tasks/configure-Solaris.yml
@@ -10,7 +10,7 @@
 
 - name: Add apache vhosts configuration.
   template:
-    src: "vhosts.conf.j2"
+    src: "{{ apache_vhosts_template }}"
     dest: "{{ apache_conf_path }}/{{ apache_vhosts_filename }}"
     owner: root
     group: root

--- a/tasks/configure-Suse.yml
+++ b/tasks/configure-Suse.yml
@@ -15,7 +15,7 @@
 
 - name: Add apache vhosts configuration.
   template:
-    src: "vhosts.conf.j2"
+    src: "{{ apache_vhosts_template }}"
     dest: "{{ apache_conf_path }}/{{ apache_vhosts_filename }}"
     owner: root
     group: root


### PR DESCRIPTION
Hi,

I would like to choose the vhosts template, without changing anything in the apache role directory.
I got a role that requires this apache role, but I need a totally different template.
Like this I can define `apache_vhosts_template = mytemplate.conf.j2` in my roles var/main.yml and use the template in my own template directory.
