### PR TITLE
Add option to disable directory-directive defaults 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ You can add or override global Apache configuration settings in the role-provide
 
 Add a set of properties per virtualhost, including `servername` (required), `documentroot` (required), `serveradmin` (optional), `serveralias` (optional) and `extra_parameters` (optional: you can add whatever additional configuration lines you'd like in here).
 
+    apache_documentroot_directory_defaults: true
+
+As the vhost file template automatically sets a default &lt;Directory&gt; directive for your document root, you can disable this by settings this value to `false` and add your own &lt;Directory&gt; directive for your document root via `extra_parameters`.
+
 Here's an example using `extra_parameters` to add a RewriteRule to redirect all requests to the `www.` site:
 
       - servername: "www.local.dev"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,10 @@ apache_remove_default_vhost: false
 apache_global_vhost_settings: |
   DirectoryIndex index.php index.html
 
+# Create default <Directory "{{apache_vhosts.documentroot}}">-Directive
+# Set this to `false` for your own <Directory>-Directive in apache_vhosts.extra_parameters
+apache_documentroot_directory_defaults: true
+
 apache_vhosts:
   # Additional properties: 'serveradmin, serveralias, extra_parameters'.
   - servername: "local.dev"

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -14,7 +14,7 @@
 {% if vhost.serveradmin is defined %}
   ServerAdmin {{ vhost.serveradmin }}
 {% endif %}
-{% if vhost.documentroot is defined %}
+{% if vhost.documentroot is defined and apache_documentroot_directory_defaults %}
   <Directory "{{ vhost.documentroot }}">
     AllowOverride All
     Options -Indexes +FollowSymLinks
@@ -61,7 +61,7 @@
 {% if vhost.serveradmin is defined %}
   ServerAdmin {{ vhost.serveradmin }}
 {% endif %}
-{% if vhost.documentroot is defined %}
+{% if vhost.documentroot is defined and apache_documentroot_directory_defaults %}
   <Directory "{{ vhost.documentroot }}">
     AllowOverride All
     Options -Indexes +FollowSymLinks


### PR DESCRIPTION
Hi folks,

I've added an option to disable the default directory-directive which is automatically set by vhosts-template when using vhost.documentroot.

Overwriting these with a second directory-directive in extra_parameters is possibe, but slighty confusing when you have to debug an incident during pager duty in a nightsession at 3 am looking to the real config on the machine. ;)

Defaults to this are untouched - if the var is untouched, everything will work as before.

Any questions: ask for it! :-)

so long,
cheGGo