### PR TITLE
Fix for "always_run" deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
 - name: Get installed version of Apache.
   shell: "{{ apache_daemon_path }}{{ apache_daemon }} -v"
   changed_when: false
-  always_run: yes
+  check_mode: no
   register: _apache_version
 
 - name: Create apache_version variable.


### PR DESCRIPTION
In ansible v2.2.1.0 getting deprecation warning:

```
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled
 by setting deprecation_warnings=False in ansible.cfg
```

This commit fixes it by replacing `always_run` with `check_mode`.