### PR TITLE
Removing deprecation warning 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Get installed version of Apache.
   shell: "{{ apache_daemon_path }}{{ apache_daemon }} -v"
   changed_when: false
-  always_run: yes
+  check_mode: no
   register: _apache_version
 
 - name: Create apache_version variable.


### PR DESCRIPTION
The playbook as is produces a deprecation warning. This PR removes that warning. @geerlingguy 


TASK [apache : Get installed version of Apache.] *******************************
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..