### PR TITLE
Add compatibility for AmazonLinux.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,11 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
+# If AmazonLinuxm include needed variables.
+- name: Include OS-specific variables.
+  include_vars: "AmazonLinux.yml"
+  when: ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA"
+
 - name: Define apache_packages.
   set_fact:
     apache_packages: "{{ __apache_packages | list }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,8 +3,7 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
-# If AmazonLinuxm include needed variables.
-- name: Include OS-specific variables.
+- name: Include variables for Amazon Linux.
   include_vars: "AmazonLinux.yml"
   when: ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA"
 

--- a/vars/AmazonLinux.yml
+++ b/vars/AmazonLinux.yml
@@ -1,0 +1,18 @@
+---
+apache_service: httpd
+apache_daemon: httpd
+apache_daemon_path: /usr/sbin/
+apache_server_root: /etc/httpd
+apache_conf_path: /etc/httpd/conf.d
+
+apache_vhosts_version: "2.4"
+
+__apache_packages:
+  - httpd24
+  - httpd24-devel
+  - mod24_ssl
+  - openssh
+
+apache_ports_configuration_items:
+  - regexp: "^Listen "
+    line: "Listen {{ apache_listen_port }}"


### PR DESCRIPTION
Ansible identifies AmazonLinux as:
  ansible_os_family: "RedHat"
  ansible_distribution_major_version == "NA"

But it is seemingly otherwise indistinguishable from RedHat / CentOS.

This sets the correct variables for packages, services, etc, which
differ from RHEL / CentOS.