### PR TITLE
Allow vhost to listen on distinct port instead of unique

### DIFF
--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -38,6 +38,17 @@
   notify: restart apache
   when: apache_create_vhosts
 
+- name: Configure Apache (Add listen port for every vhost).
+  blockinfile:
+    dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
+    insertafter: "^Listen {{ apache_listen_port }}"
+    block: "{% set return = joiner(\"\\n\") %}{% for item in apache_vhosts %}{% if item.listenport is defined and apache_listen_port != item.listenport %}{{ return() }}Listen {{ item.listenport }}{% endif %}{% endfor %}"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  when: apache_create_vhosts
+  
 - name: Add vhost symlink in sites-enabled.
   file:
     src: "{{ apache_conf_path }}/sites-available/{{ apache_vhosts_filename }}"

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -40,9 +40,15 @@
 
 - name: Configure Apache (Add listen port for every vhost).
   blockinfile:
-    dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
+    dest: "{{ apache_server_root }}/ports.conf"
     insertafter: "^Listen {{ apache_listen_port }}"
-    block: "{% set return = joiner(\"\\n\") %}{% for item in apache_vhosts %}{% if item.listenport is defined and apache_listen_port != item.listenport %}{{ return() }}Listen {{ item.listenport }}{% endif %}{% endfor %}"
+    block: "\
+    {% set return = joiner(\"\\n\") %}\
+    {% for item in apache_vhosts %}\
+      {% if item.listenport is defined and apache_listen_port != item.listenport %}\
+{{ return() }}Listen {{ item.listenport }}\
+      {% endif %}\
+    {% endfor %}"
     owner: root
     group: root
     mode: 0644

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -23,12 +23,16 @@
   notify: restart apache
   when: apache_create_vhosts  
 
-- name: Configure Apache (Add listen port for vhost).
+- name: Configure Apache (Add listen port for every vhost).
   blockinfile:
     dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
     insertafter: "^Listen {{ apache_listen_port }}"
     block: "{% set return = joiner(\"\\n\") %}{% for item in apache_vhosts %}{% if item.listenport is defined and apache_listen_port != item.listenport %}{{ return() }}Listen {{ item.listenport }}{% endif %}{% endfor %}"
+    owner: root
+    group: root
+    mode: 0644
   notify: restart apache
+  when: apache_create_vhosts 
 
 
 

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -21,4 +21,15 @@
     group: root
     mode: 0644
   notify: restart apache
-  when: apache_create_vhosts
+  when: apache_create_vhosts  
+
+- name: Configure Apache (Add listen port for vhost).
+  blockinfile:
+    dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
+    insertafter: "^Listen {{ apache_listen_port }}"
+    block: "{% set return = joiner(\"\\n\") %}{% for item in apache_vhosts %}{% if item.listenport is defined and apache_listen_port != item.listenport %}{{ return() }}Listen {{ item.listenport }}{% endif %}{% endfor %}"
+  notify: restart apache
+
+
+
+

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -27,7 +27,13 @@
   blockinfile:
     dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
     insertafter: "^Listen {{ apache_listen_port }}"
-    block: "{% set return = joiner(\"\\n\") %}{% for item in apache_vhosts %}{% if item.listenport is defined and apache_listen_port != item.listenport %}{{ return() }}Listen {{ item.listenport }}{% endif %}{% endfor %}"
+    block: "\
+    {% set return = joiner(\"\\n\") %}\
+    {% for item in apache_vhosts %}\
+      {% if item.listenport is defined and apache_listen_port != item.listenport %}\
+{{ return() }}Listen {{ item.listenport }}\
+      {% endif %}\
+    {% endfor %}"
     owner: root
     group: root
     mode: 0644

--- a/tasks/configure-Solaris.yml
+++ b/tasks/configure-Solaris.yml
@@ -20,9 +20,15 @@
 
   - name: Configure Apache (Add listen port for every vhost).
   blockinfile:
-    dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
+    dest: "{{ apache_server_root }}/{{ apache_daemon }}.conf"
     insertafter: "^Listen {{ apache_listen_port }}"
-    block: "{% set return = joiner(\"\\n\") %}{% for item in apache_vhosts %}{% if item.listenport is defined and apache_listen_port != item.listenport %}{{ return() }}Listen {{ item.listenport }}{% endif %}{% endfor %}"
+    block: "\
+    {% set return = joiner(\"\\n\") %}\
+    {% for item in apache_vhosts %}\
+      {% if item.listenport is defined and apache_listen_port != item.listenport %}\
+{{ return() }}Listen {{ item.listenport }}\
+      {% endif %}\
+    {% endfor %}"
     owner: root
     group: root
     mode: 0644

--- a/tasks/configure-Solaris.yml
+++ b/tasks/configure-Solaris.yml
@@ -17,3 +17,14 @@
     mode: 0644
   notify: restart apache
   when: apache_create_vhosts
+
+  - name: Configure Apache (Add listen port for every vhost).
+  blockinfile:
+    dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
+    insertafter: "^Listen {{ apache_listen_port }}"
+    block: "{% set return = joiner(\"\\n\") %}{% for item in apache_vhosts %}{% if item.listenport is defined and apache_listen_port != item.listenport %}{{ return() }}Listen {{ item.listenport }}{% endif %}{% endfor %}"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  when: apache_create_vhosts

--- a/tasks/configure-Suse.yml
+++ b/tasks/configure-Suse.yml
@@ -22,3 +22,14 @@
     mode: 0644
   notify: restart apache
   when: apache_create_vhosts
+
+- name: Configure Apache (Add listen port for every vhost).
+  blockinfile:
+    dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
+    insertafter: "^Listen {{ apache_listen_port }}"
+    block: "{% set return = joiner(\"\\n\") %}{% for item in apache_vhosts %}{% if item.listenport is defined and apache_listen_port != item.listenport %}{{ return() }}Listen {{ item.listenport }}{% endif %}{% endfor %}"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  when: apache_create_vhosts

--- a/tasks/configure-Suse.yml
+++ b/tasks/configure-Suse.yml
@@ -25,9 +25,15 @@
 
 - name: Configure Apache (Add listen port for every vhost).
   blockinfile:
-    dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
+    dest: "{{ apache_server_root }}/listen.conf"
     insertafter: "^Listen {{ apache_listen_port }}"
-    block: "{% set return = joiner(\"\\n\") %}{% for item in apache_vhosts %}{% if item.listenport is defined and apache_listen_port != item.listenport %}{{ return() }}Listen {{ item.listenport }}{% endif %}{% endfor %}"
+    block: "\
+    {% set return = joiner(\"\\n\") %}\
+    {% for item in apache_vhosts %}\
+      {% if item.listenport is defined and apache_listen_port != item.listenport %}\
+{{ return() }}Listen {{ item.listenport }}\
+      {% endif %}\
+    {% endfor %}"
     owner: root
     group: root
     mode: 0644

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -2,7 +2,7 @@
 
 {# Set up VirtualHosts #}
 {% for vhost in apache_vhosts %}
-<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
+<VirtualHost {{ apache_listen_ip }}:{{ vhost.listenport }}>
   ServerName {{ vhost.servername }}
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -2,7 +2,7 @@
 
 {# Set up VirtualHosts #}
 {% for vhost in apache_vhosts %}
-<VirtualHost {{ apache_listen_ip }}:{{ vhost.listenport }}>
+<VirtualHost {{ apache_listen_ip }}:{% if vhost.listenport is defined %}{{ vhost.listenport }}{% else %}{{ apache_listen_port }}{% endif %}>
   ServerName {{ vhost.servername }}
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}


### PR DESCRIPTION
This PR allow to configure the port of every vhost.

On apache_vhost configuration add listenport parameter on every vhost like this

    apache_vhosts:
      - {
        servername: "local.dev",
        listenport: 80,
        ....
      }
      - {
        servername: "local.dev",
        listenport: 9000,
        ....
      }