### PR TITLE
The documentroot paths for the vhosts were not encapsulated in quotes…

### DIFF
--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -8,7 +8,7 @@
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
 {% if vhost.documentroot is defined %}
-  DocumentRoot {{ vhost.documentroot }}
+  DocumentRoot "{{ vhost.documentroot }}"
 {% endif %}
 
 {% if vhost.serveradmin is defined %}
@@ -42,7 +42,7 @@
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
 {% if vhost.documentroot is defined %}
-  DocumentRoot {{ vhost.documentroot }}
+  DocumentRoot "{{ vhost.documentroot }}"
 {% endif %}
 
   SSLEngine on


### PR DESCRIPTION
… which would cause an apache error for paths with spaces or other restricted characters