### PR TITLE
Deleting default files for CentOS/RedHat and ssl default file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,9 +9,21 @@ apache_create_vhosts: true
 apache_vhosts_filename: "vhosts.conf"
 apache_vhosts_template: "vhosts.conf.j2"
 
-# On Debian/Ubuntu, a default virtualhost is included in Apache's configuration.
-# Set this to `true` to remove that default.
+# Delete default virtualhost files included in Apache's configuration.
+# The set of files varies with OS and Apache version.
+# This role by default removes:
+# for Apache 2.2: 000-default, welcome.conf, userdir.conf, autoindex.conf
+# for Apache 2.4: 000-default.conf, welcome.conf, userdir.conf, autoindex.conf
+# Set this to `true` to remove these default files.
 apache_remove_default_vhost: false
+
+# Delete default SSL virtualhost files included in Apache's configuration.
+# The set of files varies with OS and Apache version.
+# This role by default removes:
+# for Apache 2.2: ssl.conf
+# for Apache 2.4: ssl.conf
+# Set this to `true` to remove these default files.
+apache_remove_default_vhost_ssl: false
 
 apache_global_vhost_settings: |
   DirectoryIndex index.php index.html

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -48,7 +48,17 @@
 
 - name: Remove default vhost in sites-enabled.
   file:
-    path: "{{ apache_conf_path }}/sites-enabled/{{ apache_default_vhost_filename }}"
+    path: "{{ apache_conf_path }}/sites-enabled/{{ item }}"
     state: absent
   notify: restart apache
+  with_items: "{{ apache_default_vhost_filenames }}"
   when: apache_remove_default_vhost
+
+- name: Remove default vhost_ssl in sites-enabled.
+  file:
+    path: "{{ apache_conf_path }}/{{ item }}"
+    state: absent
+  notify: restart apache
+  with_items: "{{ apache_default_vhost_ssl_filenames }}"
+  when: apache_remove_default_vhost_ssl
+  

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -22,3 +22,19 @@
     mode: 0644
   notify: restart apache
   when: apache_create_vhosts
+
+- name: Remove default vhost configurations
+  file:
+    path: "{{ apache_conf_path }}{{ item }}"
+    state: absent
+  notify: restart apache
+  with_items: "{{ apache_default_vhost_filenames }}"
+  when: apache_remove_default_vhost
+
+- name: Remove default vhost ssl configurations
+  file:
+    path: "{{ apache_conf_path }}{{ item }}"
+    state: absent
+  notify: restart apache
+  with_items: "{{ apache_default_vhost_ssl_filenames }}"
+  when: apache_remove_default_vhost_ssl

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -25,7 +25,7 @@
 
 - name: Remove default vhost configurations
   file:
-    path: "{{ apache_conf_path }}{{ item }}"
+    path: "{{ apache_conf_path }}/{{ item }}"
     state: absent
   notify: restart apache
   with_items: "{{ apache_default_vhost_filenames }}"
@@ -33,7 +33,7 @@
 
 - name: Remove default vhost ssl configurations
   file:
-    path: "{{ apache_conf_path }}{{ item }}"
+    path: "{{ apache_conf_path }}/{{ item }}"
     state: absent
   notify: restart apache
   with_items: "{{ apache_default_vhost_ssl_filenames }}"

--- a/vars/apache-22.yml
+++ b/vars/apache-22.yml
@@ -1,6 +1,12 @@
 ---
 apache_vhosts_version: "2.2"
-apache_default_vhost_filename: 000-default
+apache_default_vhost_filenames: 
+  - 000-default
+  - welcome.conf
+  - userdir.conf
+  - autoindex.conf
+apache_default_vhost_ssl_filenames: 
+  - ssl.conf
 apache_ports_configuration_items:
   - {
     regexp: "^Listen ",

--- a/vars/apache-24.yml
+++ b/vars/apache-24.yml
@@ -1,6 +1,12 @@
 ---
 apache_vhosts_version: "2.4"
-apache_default_vhost_filename: 000-default.conf
+apache_default_vhost_filenames: 
+  - 000-default.conf
+  - welcome.conf
+  - userdir.conf
+  - autoindex.conf
+apache_default_vhost_ssl_filenames: 
+  - ssl.conf
 apache_ports_configuration_items:
   - {
     regexp: "^Listen ",


### PR DESCRIPTION
This is an attempt to solve issues:

https://github.com/geerlingguy/ansible-role-apache/issues/81 https://github.com/geerlingguy/ansible-role-apache/issues/21

In summary the default vhost file variable now holds an array, and there is a variable for ssl vhosts as well.
Looks like the set of default files varies depending on OS and Apache version; perhaps there is a better way to organise the variables.