### PR TITLE
Don't start service if ANSIBLE_CONTAINER

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,4 @@
   service:
     name: "{{ apache_service }}"
     state: "{{ apache_restart_state }}"
+  when: ansible_container == '0'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,10 @@
     apache_packages: "{{ __apache_packages | list }}"
   when: apache_packages is not defined
 
+- name: Define ansible_container
+  set_fact:
+    ansible_container: "{{ lookup('env', 'ANSIBLE_CONTAINER') | default('0') }}"
+
 # Setup/install tasks.
 - include: "setup-{{ ansible_os_family }}.yml"
   static: no
@@ -42,3 +46,4 @@
     name: "{{ apache_service }}"
     state: "{{ apache_state }}"
     enabled: yes
+  when: ansible_container == '0'


### PR DESCRIPTION
Sets `ansible_container` fact based on existence of ANSIBLE_CONTAINER environment variable. Conditionally start the httpd service if `ansible_container == '0'`, meaning that the environment variable is not set, and we're not executing inside a container.