### PR TITLE
Removed inconsistent ssl vhost example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,14 @@ The `|` denotes a multiline scalar block in YAML, so newlines are preserved in t
 No SSL vhosts are configured by default, but you can add them using the same pattern as `apache_vhosts`, with a few additional directives, like the following example:
 
     apache_vhosts_ssl:
-      - {
-        servername: "local.dev",
+      - servername: "local.dev",
         documentroot: "/var/www/html",
         certificate_file: "/home/vagrant/example.crt",
         certificate_key_file: "/home/vagrant/example.key",
         certificate_chain_file: "/path/to/certificate_chain.crt"
-      }
+        extra_parameters: |
+          RewriteCond %{HTTP_HOST} !^www\. [NC]
+          RewriteRule ^(.*)$ http://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
 Other SSL directives can be managed with other SSL-related role variables.
 


### PR DESCRIPTION
This example freaked me out. Took some time till I figured out that I have to remove the brackets and fix the spacings to add extra_parameters to the ssl vhost configuration. For me it would have been easier this way. Maybe you agree with me.

Thanks a lot already for this awesome ansible book! 

Greetings
~ ArgonQQ