### PR TITLE
Includes tasks with_first_found

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
   static: no
   with_first_found:
   - files: setup-{{ ansible_os_family }}.yml
-  - skip: yes
+    skip: yes
 
 # Figure out what version of Apache is installed.
 - name: Get installed version of Apache.
@@ -41,7 +41,7 @@
   static: no
   with_first_found:
   - files: configure-{{ ansible_os_family }}.yml
-  - skip: yes
+    skip: yes
 
 - name: Ensure Apache has selected state and enabled on boot.
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,8 +13,11 @@
   when: apache_packages is not defined
 
 # Setup/install tasks.
-- include: "setup-{{ ansible_os_family }}.yml"
+- include: "{{ item }}"
   static: no
+  with_first_found:
+  - files: setup-{{ ansible_os_family }}.yml
+  - skip: yes
 
 # Figure out what version of Apache is installed.
 - name: Get installed version of Apache.
@@ -34,8 +37,11 @@
   when: "apache_version.split('.')[1] == '4'"
 
 # Configure Apache.
-- include: "configure-{{ ansible_os_family }}.yml"
+- include: "{{ item }}"
   static: no
+  with_first_found:
+  - files: configure-{{ ansible_os_family }}.yml
+  - skip: yes
 
 - name: Ensure Apache has selected state and enabled on boot.
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,11 +13,13 @@
   when: apache_packages is not defined
 
 # Setup/install tasks.
-- include: "{{ item }}"
+- include: "{{ os_family }}"
   static: no
   with_first_found:
   - files: setup-{{ ansible_os_family }}.yml
     skip: yes
+  loop_control:
+    loop_var: os_family
 
 # Figure out what version of Apache is installed.
 - name: Get installed version of Apache.
@@ -37,11 +39,13 @@
   when: "apache_version.split('.')[1] == '4'"
 
 # Configure Apache.
-- include: "{{ item }}"
+- include: "{{ os_family }}"
   static: no
   with_first_found:
   - files: configure-{{ ansible_os_family }}.yml
     skip: yes
+  loop_control:
+    loop_var: os_family
 
 - name: Ensure Apache has selected state and enabled on boot.
   service:


### PR DESCRIPTION
PROBLEM
=====
In a playbook, include this role:

```yaml
- hosts: webserver
  tags: web
  any_errors_fatal: true
  gather_facts: false
  become: yes
  roles:
  - ansible-role-apache
```

Then include this playbook in another playbook:

```yaml
- include: another-playbook.yml
- include: web-server.yml
```

If you run ansible with --tags and do not specify the webserver tag, eg:

`ansible-playbook playbook.yml --tags another-tag`

then ansible will fail if running on a machine other than Ubuntu, RedHat, etc. The problem is that include statements in tasks/main.yml contain the variable `ansible_os_family` which will be evaluated even when --tags does not contain the webserver. 