### PR TITLE
Avoid adding empty ServerAlias directives.

### DIFF
--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -4,7 +4,7 @@
 {% for vhost in apache_vhosts %}
 <VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
   ServerName {{ vhost.servername }}
-{% if vhost.serveralias is defined %}
+{% if vhost.serveralias is defined and vhost.serveralias %}
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
 {% if vhost.documentroot is defined %}
@@ -38,7 +38,7 @@
 {% if apache_ignore_missing_ssl_certificate or apache_ssl_certificates.results[loop.index0].stat.exists %}
 <VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port_ssl }}>
   ServerName {{ vhost.servername }}
-{% if vhost.serveralias is defined %}
+{% if vhost.serveralias is defined and vhost.serveralias %}
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
 {% if vhost.documentroot is defined %}


### PR DESCRIPTION
I have a list of virtualhost dicts, which contain a list of hostname. My playbook has the convention to use the first hostname as the servername, and any subsequent hostnames as serveraliases.
This is used to rewrite all the serveraliases to the servername.
So for instance

```
virtualhosts:
  example:
    hostnames:
     - example.com
     - www.example.com
     - example.org
     - www.example.org
    rootdir: /var/www/blah/web
  merchant1:
    hostnames:
     - www.merchant1.com
    rootdir: /var/www/merch/1/www
    contact: blah2@example.com
  

```
which is later used to popluate the `apache_vhosts` dict:

```
apache_vhosts:
  - servername: "{{ hostnames[0] }}"
    serveralias: "{{ hostnames[1:] | join(', ') }}"
    documentroot: "{{ rootdir }}" 
    extra_parameters: |
      RewriteEngine On
      RewriteCond %{HTTP_HOST} !^{{ hostnames[0] }}$
      RewriteRule . http://{{ hostnames[0] }}%{REQUEST_URI}
 - etc
```

This works, but because some virtualhosts have just one hostname, the serveralias will be an empty string in the resulting configuration:

```
ServerName www.merchant1.com
ServerAlias
```

The template only checks for `defined` so there will appear an empty ServerAlias statement in the config.
This patch fixes that so empty strings don't appear any more.
