### PR TITLE
use apache2_module to handle modules

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,8 +42,8 @@ apache_ssl_cipher_suite: "AES256+EECDH:AES256+EDH"
 
 # Only used on Debian/Ubuntu.
 apache_mods_enabled:
-  - rewrite.load
-  - ssl.load
+  - rewrite
+  - ssl
 apache_mods_disabled: []
 
 # Set initial apache state. Recommended values: `started` or `stopped`

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -9,16 +9,15 @@
   notify: restart apache
 
 - name: Enable Apache mods.
-  file:
-    src: "{{ apache_server_root }}/mods-available/{{ item }}"
-    dest: "{{ apache_server_root }}/mods-enabled/{{ item }}"
-    state: link
+  apache2_module:
+    name: "{{ item }}"
+    state: present
   with_items: "{{ apache_mods_enabled }}"
   notify: restart apache
 
 - name: Disable Apache mods.
-  file:
-    path: "{{ apache_server_root }}/mods-enabled/{{ item }}"
+  apache2_module:
+    name: "{{ item }}"
     state: absent
   with_items: "{{ apache_mods_disabled }}"
   notify: restart apache

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -10,14 +10,14 @@
 
 - name: Enable Apache mods.
   apache2_module:
-    name: "{{ item }}"
+    name: "{{ item|regex_replace('\\.load$', '') }}"
     state: present
   with_items: "{{ apache_mods_enabled }}"
   notify: restart apache
 
 - name: Disable Apache mods.
   apache2_module:
-    name: "{{ item }}"
+    name: "{{ item|regex_replace('\\.load$', '') }}"
     state: absent
   with_items: "{{ apache_mods_disabled }}"
   notify: restart apache


### PR DESCRIPTION
use ansible apache2_module to handle management of modules. This respects the declared dependencies of modules as it will internally use a2enmod.

fixes #139