### PR TITLE
Removed commas from apache_vhosts_ssl variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ The `|` denotes a multiline scalar block in YAML, so newlines are preserved in t
 No SSL vhosts are configured by default, but you can add them using the same pattern as `apache_vhosts`, with a few additional directives, like the following example:
 
     apache_vhosts_ssl:
-      - servername: "local.dev",
-        documentroot: "/var/www/html",
-        certificate_file: "/home/vagrant/example.crt",
-        certificate_key_file: "/home/vagrant/example.key",
+      - servername: "local.dev"
+        documentroot: "/var/www/html"
+        certificate_file: "/home/vagrant/example.crt"
+        certificate_key_file: "/home/vagrant/example.key"
         certificate_chain_file: "/path/to/certificate_chain.crt"
         extra_parameters: |
           RewriteCond %{HTTP_HOST} !^www\. [NC]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,10 +28,10 @@ apache_options: "-Indexes +FollowSymLinks"
 apache_vhosts_ssl: []
   # Additional properties:
   # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
-  # - servername: "local.dev",
-  #   documentroot: "/var/www/html",
-  #   certificate_file: "/path/to/certificate.crt",
-  #   certificate_key_file: "/path/to/certificate.key",
+  # - servername: "local.dev"
+  #   documentroot: "/var/www/html"
+  #   certificate_file: "/path/to/certificate.crt"
+  #   certificate_key_file: "/path/to/certificate.key"
   #   # Optional.
   #   certificate_chain_file: "/path/to/certificate_chain.crt"
 


### PR DESCRIPTION
If I want to add some SSL virtual host directives should be declared without commas the same like "apache_vhosts" variable.