### PR TITLE
Add support for apache_listen_port_ssl for Debian, RedHat, Suse and AmazonLinux.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ apache_enablerepo: ""
 
 apache_listen_ip: "*"
 apache_listen_port: 80
+# supported on Debian, RedHat/Amazon Linux and SUSE
 apache_listen_port_ssl: 443
 
 apache_create_vhosts: true
@@ -40,10 +41,11 @@ apache_ignore_missing_ssl_certificate: true
 apache_ssl_protocol: "All -SSLv2 -SSLv3"
 apache_ssl_cipher_suite: "AES256+EECDH:AES256+EDH"
 
-# Only used on Debian/Ubuntu.
+# Only used on Debian, RedHat and SUSE based OS.
+# You can use either the old format of this role (e.g. rewrite.role) or use mod name as below
 apache_mods_enabled:
-  - rewrite.load
-  - ssl.load
+  - rewrite
+  - ssl
 apache_mods_disabled: []
 
 # Set initial apache state. Recommended values: `started` or `stopped`

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -1,24 +1,33 @@
 ---
-- name: Configure Apache.
+- name: Configure Apache (lineinfile - legacy).
   lineinfile:
     dest: "{{ apache_server_root }}/ports.conf"
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
     state: present
   with_items: "{{ apache_ports_configuration_items }}"
+  when: item.line is defined
+  notify: restart apache
+
+- name: Configure Apache (replace).
+  replace:
+    path: "{{ apache_server_root }}/ports.conf"
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items: "{{ apache_ports_configuration_items }}"
+  when: item.replace is defined
   notify: restart apache
 
 - name: Enable Apache mods.
-  file:
-    src: "{{ apache_server_root }}/mods-available/{{ item }}"
-    dest: "{{ apache_server_root }}/mods-enabled/{{ item }}"
-    state: link
+  apache2_module:
+    name: "{{ item | regex_replace('(\\w+)\\.load','\\1') }}"
+    state: present
   with_items: "{{ apache_mods_enabled }}"
   notify: restart apache
 
 - name: Disable Apache mods.
-  file:
-    path: "{{ apache_server_root }}/mods-enabled/{{ item }}"
+  apache2_module:
+    name: "{{ item | regex_replace('(\\w+)\\.load','\\1') }}"
     state: absent
   with_items: "{{ apache_mods_disabled }}"
   notify: restart apache

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -1,11 +1,42 @@
 ---
-- name: Configure Apache.
+- name: Install SELinux Python dependencies.
+  package:
+    name: libselinux-python
+    state: present
+
+- name: Enable Apache mods.
+  apache2_module:
+    name: "{{ item | regex_replace('(\\w+)\\.load','\\1') }}"
+    state: present
+  with_items: "{{ apache_mods_enabled }}"
+  notify: restart apache
+
+- name: Disable Apache mods.
+  apache2_module:
+    name: "{{ item | regex_replace('(\\w+)\\.load','\\1') }}"
+    state: absent
+  with_items: "{{ apache_mods_disabled }}"
+  notify: restart apache
+
+- name: Configure Apache httpd.conf (lineinfile - legacy).
   lineinfile:
     dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
     state: present
   with_items: "{{ apache_ports_configuration_items }}"
+  when: item.line is defined
+  notify: restart apache
+
+- name: Configure Apache ssl.conf (replace).
+  replace:
+    dest: "{{ apache_server_root }}/conf.d/ssl.conf"
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items: "{{ apache_ports_configuration_items }}"
+  when:
+    - item.replace is defined
+    - '"ssl.load" in apache_mods_enabled or "ssl" in apache_mods_enabled'
   notify: restart apache
 
 - name: Check whether certificates defined in vhosts exist.

--- a/tasks/configure-Solaris.yml
+++ b/tasks/configure-Solaris.yml
@@ -1,11 +1,12 @@
 ---
-- name: Configure Apache.
+- name: Configure Apache httpd.conf (lineinfile - legacy).
   lineinfile:
     dest: "{{ apache_server_root }}/{{ apache_daemon }}.conf"
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
     state: present
   with_items: "{{ apache_ports_configuration_items }}"
+  when: item.line is defined
   notify: restart apache
 
 - name: Add apache vhosts configuration.

--- a/tasks/configure-Suse.yml
+++ b/tasks/configure-Suse.yml
@@ -1,11 +1,35 @@
 ---
-- name: Configure Apache.
+- name: Configure Apache (lineinfile - legacy).
   lineinfile:
     dest: "{{ apache_server_root }}/listen.conf"
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
     state: present
   with_items: "{{ apache_ports_configuration_items }}"
+  when: item.line is defined
+  notify: restart apache
+
+- name: Configure Apache (replace).
+  replace:
+    path: "{{ apache_server_root }}/listen.conf"
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items: "{{ apache_ports_configuration_items }}"
+  when: item.replace is defined
+  notify: restart apache
+
+- name: Enable Apache mods.
+  apache2_module:
+    name: "{{ item | regex_replace('(\\w+)\\.load','\\1') }}"
+    state: present
+  with_items: "{{ apache_mods_enabled }}"
+  notify: restart apache
+
+- name: Disable Apache mods.
+  apache2_module:
+    name: "{{ item | regex_replace('(\\w+)\\.load','\\1') }}"
+    state: absent
+  with_items: "{{ apache_mods_disabled }}"
   notify: restart apache
 
 - name: Check whether certificates defined in vhosts exist.

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -8,11 +8,7 @@ apache_conf_path: /etc/httpd/conf.d
 apache_vhosts_version: "2.4"
 
 __apache_packages:
-  - httpd24
-  - httpd24-devel
-  - mod24_ssl
+  - httpd
+  - httpd-devel
+  - mod_ssl
   - openssh
-
-apache_ports_configuration_items:
-  - regexp: "^Listen "
-    line: "Listen {{ apache_listen_port }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,7 +8,3 @@ apache_conf_path: /etc/apache2
 __apache_packages:
   - apache2
   - apache2-utils
-
-apache_ports_configuration_items:
-  - regexp: "^Listen "
-    line: "Listen {{ apache_listen_port }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -12,9 +12,3 @@ __apache_packages:
   - httpd-devel
   - mod_ssl
   - openssh
-
-apache_ports_configuration_items:
-  - regexp: "^Listen "
-    line: "Listen {{ apache_listen_port }}"
-  - regexp: "^#?NameVirtualHost "
-    line: "NameVirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}"

--- a/vars/Solaris.yml
+++ b/vars/Solaris.yml
@@ -11,9 +11,3 @@ __apache_packages:
   - web/server/apache-24
   - web/server/apache-24/module/apache-ssl
   - web/server/apache-24/module/apache-security
-
-apache_ports_configuration_items:
-  - regexp: "^Listen "
-    line: "Listen {{ apache_listen_port }}"
-  - regexp: "^#?NameVirtualHost "
-    line: "NameVirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}"

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -1,18 +1,12 @@
 ---
 apache_service: apache2
-apache_daemon: httpd2
+apache_daemon: httpd
 apache_daemon_path: /usr/sbin/
 apache_server_root: /etc/apache2
 apache_conf_path: /etc/apache2/conf.d
 
-apache_vhosts_version: "2.2"
+apache_vhosts_version: "2.4"
 
 __apache_packages:
   - apache2
   - openssh
-
-apache_ports_configuration_items:
-  - regexp: "^Listen "
-    line: "Listen {{ apache_listen_port }}"
-  - regexp: "^#?NameVirtualHost "
-    line: "NameVirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}"

--- a/vars/apache-22.yml
+++ b/vars/apache-22.yml
@@ -1,12 +1,25 @@
 ---
 apache_vhosts_version: "2.2"
 apache_default_vhost_filename: 000-default
+
 apache_ports_configuration_items:
+  # Debian, Ubuntu and RedHat
   - {
-    regexp: "^Listen ",
+    regexp: "^Listen\\s+\\d+$",
     line: "Listen {{ apache_listen_port }}"
   }
+  # Debian/Ubuntu
   - {
     regexp: "^#?NameVirtualHost ",
     line: "NameVirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}"
+  }
+  # Debian/Ubuntu (SSL)
+  - {
+    regexp: "^(<IfModule\\s+.+>(?:\\n+\\s+#.+)*\\s+)Listen\\s+\\d+$",
+    replace: "\\1Listen {{ apache_listen_port_ssl }}"
+  }
+  # RedHat/CentOS 6 (SSL)
+  - {
+    regexp: "^(LoadModule\\s+ssl_module\\s+.*(?:\\n.*)*)Listen\\s+\\d+$",
+    replace: "\\1Listen {{ apache_listen_port_ssl }}"
   }

--- a/vars/apache-24.yml
+++ b/vars/apache-24.yml
@@ -1,8 +1,25 @@
 ---
 apache_vhosts_version: "2.4"
 apache_default_vhost_filename: 000-default.conf
+
 apache_ports_configuration_items:
+  # Debian/Ubuntu and RedHat/CentOS/Amazon Linux Regex for http
   - {
-    regexp: "^Listen ",
-    line: "Listen {{ apache_listen_port }}"
+      regexp: "^Listen\\s+\\d+$",
+      line: "Listen {{ apache_listen_port }}"
+  }
+  # RedHat/CentOS 7, Amazon Linux
+  - {
+      regexp: "^Listen\\s+\\d+\\s+https$",
+      replace: "Listen {{ apache_listen_port_ssl }} https"
+  }
+  # Debian, SUSE
+  - {
+      regexp: "^(\\s*<IfModule\\s+.+>(?:\\n+\\s+#.+)*\\s+)Listen\\s+\\d+",
+      replace: "\\1Listen {{ apache_listen_port_ssl }}"
+  }
+  # SUSE
+  - {
+      regexp: "^(# - name-based virtual hosting:\\n(?:#\\n)*)#?\\s*NameVirtualHost\\s+.*:\\d+",
+      replace: "\\1NameVirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}"
   }


### PR DESCRIPTION
This PR will add support for `apache_listen_port_ssl` for Debian, RedHat, Suse and Amazon Linux as this is currently not implemented.
I have to admit that the regular expressions are quite complex. One solution to simplify them would be to create os family and apache version specific var files.

# Changes:

## Apache Listen Port
* Removed `apache_ports_configuration_items` from os family vars since they are overwritten by the apache vars anyways
* Kept line in file mechanism in order to be backward compatibel
* Added new regexp mechanism to apply changes to the configuration files
* Added regex for apache 2.2 and apache 2.4 in order to set `apache_listen_port` and `apache_listen_port_ssl`

## Apache Modules
* Switched enabling and enabling of apache mods to ansible apache2_module
** Old <module>.load syntax for `apache_mods_enabled` and`apache_mods_disabled` is still supported
* Added apache module enabling / disabling for RedHat/Amazon Linux and Suse

## Amazon Linux
* Updated `__apache_packages` since configured packages were not found during testing

# Tested on:
* Debian 7
* Debian 8
* Debian 9
* CentOS 6
* CentOS 7
* SLES 12.3
* OpenSuse 42.2
* OpenSuse 42.3
* Solaris 11
* Amazon Linux 2016.03
* Amazon Linux 2016.09
* Amazon Linux 2017.03

The tests from `tests/` have also passed for
* CentOS 6
* CentOS 7
* Ubuntu 1804
* Ubuntu 1604
* Ubuntu 1204
* Ubuntu Debian 9
* Ubuntu Debian 8