### PR TITLE
Remove checks for certificate to allow global certificate for all vhosts

### DIFF
--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -23,11 +23,6 @@
   with_items: "{{ apache_mods_disabled }}"
   notify: restart apache
 
-- name: Check whether certificates defined in vhosts exist.
-  stat: "path={{ item.certificate_file }}"
-  register: apache_ssl_certificates
-  with_items: "{{ apache_vhosts_ssl }}"
-
 - name: Add apache vhosts configuration.
   template:
     src: "{{ apache_vhosts_template }}"

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -8,11 +8,6 @@
   with_items: "{{ apache_ports_configuration_items }}"
   notify: restart apache
 
-- name: Check whether certificates defined in vhosts exist.
-  stat: path={{ item.certificate_file }}
-  register: apache_ssl_certificates
-  with_items: "{{ apache_vhosts_ssl }}"
-
 - name: Add apache vhosts configuration.
   template:
     src: "{{ apache_vhosts_template }}"

--- a/tasks/configure-Suse.yml
+++ b/tasks/configure-Suse.yml
@@ -8,11 +8,6 @@
   with_items: "{{ apache_ports_configuration_items }}"
   notify: restart apache
 
-- name: Check whether certificates defined in vhosts exist.
-  stat: path={{ item.certificate_file }}
-  register: apache_ssl_certificates
-  with_items: "{{ apache_vhosts_ssl }}"
-
 - name: Add apache vhosts configuration.
   template:
     src: "{{ apache_vhosts_template }}"

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -52,8 +52,13 @@
 {% if apache_vhosts_version == "2.4" %}
   SSLCompression off
 {% endif %}
+{% if vhost.certificate_file is defined %}
   SSLCertificateFile {{ vhost.certificate_file }}
+{% endif %}
+{% if vhost.certificate_key_file is defined %}
   SSLCertificateKeyFile {{ vhost.certificate_key_file }}
+{% endif %}
+
 {% if vhost.certificate_chain_file is defined %}
   SSLCertificateChainFile {{ vhost.certificate_chain_file }}
 {% endif %}


### PR DESCRIPTION
### Problem
I've got many sites (~25) going on one drupalvm and there is a terrible amount of duplication in my `local.config.yml`

The only difference between `apache_vhosts` and `apache_vhosts_ssl` in my case is the `certificate_file` and `certificate_key_file` variables.

### Proposed Solution
With this change you can avoid half the duplicate vhosts:
```
apache_vhosts_ssl: "{{ apache_vhosts }}"
```
But you still need a required cert files on each vhost...
To avoid this duplication of this file in all the vhost put the `certificate_file`/`certificate_key_file` in the **server config**:
```
apache_global_vhost_settings: |
  # Global SSL certificate.
  SSLCertificateFile {{ certificate_file }}
  SSLCertificateKeyFile {{ certificate_key_file }}
```

I've removed the checks for the cert files in the `apache_vhosts_ssl` list, to allow this configuration to be possible.