### PR TITLE
Configures apache modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,15 @@ The default values for the `AllowOverride` and `Options` directives for the `doc
       - rewrite.load
       - ssl.load
     apache_mods_disabled: []
+    apache_mods_config:
+      mpm_prefork: |
+        StartServers     3
+        MinSpareServers  3
+        MaxSpareServers  5
+        MaxRequestWorkers 25
+        MaxConnectionsPerChild   1024
 
-(Debian/Ubuntu ONLY) Which Apache mods to enable or disable (these will be symlinked into the appropriate location). See the `mods-available` directory inside the apache configuration directory (`/etc/apache2/mods-available` by default) for all the available mods.
+(Debian/Ubuntu ONLY) Which Apache mods to enable or disable (these will be symlinked into the appropriate location). See the `mods-available` directory inside the apache configuration directory (`/etc/apache2/mods-available` by default) for all the available mods. `apache_mods_config` entries will be converted into conf files (under `/etc/apache2/mods-available/` by default). The contents will be wrapped in `<IfModule>` statements.
 
     apache_packages:
       - [platform-specific]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,8 @@ apache_mods_enabled:
   - ssl.load
 apache_mods_disabled: []
 
+apache_mods_config: {}
+
 # Set initial apache state. Recommended values: `started` or `stopped`
 apache_state: started
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,9 +25,6 @@ galaxy_info:
         - trusty
         - xenial
         - bionic
-    - name: Suse
-      versions:
-        - all
     - name: Solaris
       versions:
         - 11.3

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -36,6 +36,14 @@
   notify: restart apache
   with_dict: "{{ apache_mods_config }}"
 
+- name: Enable Apache mod configs.
+  file:
+    src: "{{ apache_server_root }}/mods-available/{{ item }}"
+    dest: "{{ apache_server_root }}mods-enabled/{{ item }}"
+    state: link
+  notify: restart apache
+  with_dict: "{{ apache_mods_config }}"
+
 - name: Check whether certificates defined in vhosts exist.
   stat: "path={{ item.certificate_file }}"
   register: apache_ssl_certificates

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -23,6 +23,19 @@
   with_items: "{{ apache_mods_disabled }}"
   notify: restart apache
 
+- name: Configure Apache mods.
+  copy:
+    content: >
+      <IfModule {{ item.key }}_module>
+        {{ item.value }}
+      </IfModule>
+    dest: "{{ apache_server_root }}/mods-available/{{ item.key }}.conf"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  with_dict: "{{ apache_mods_config }}"
+
 - name: Check whether certificates defined in vhosts exist.
   stat: "path={{ item.certificate_file }}"
   register: apache_ssl_certificates


### PR DESCRIPTION
Adds a `apache_mods_config` hash that will be transformed into conf files under `/etc/apache/mods-available/`, adding `<IfModule>` statements. This is valid only for Ubuntu/Debian. I didn't find a way configure modules with the role as is.