### PR TITLE
Bugfix/suse apache

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,6 +28,12 @@ galaxy_info:
     - name: Solaris
       versions:
         - 11.3
+    - name: opensuse
+      versions:
+        - all
+    - name: SLES
+      versions:
+        - all
   galaxy_tags:
     - web
     - apache

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -1,7 +1,7 @@
 ---
 - name: Configure Apache.
   lineinfile:
-    dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
+    dest: "{{ apache_server_root }}/conf/httpd.conf"
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
     state: present

--- a/tasks/configure-Solaris.yml
+++ b/tasks/configure-Solaris.yml
@@ -1,7 +1,7 @@
 ---
 - name: Configure Apache.
   lineinfile:
-    dest: "{{ apache_server_root }}/{{ apache_daemon }}.conf"
+    dest: "{{ apache_server_root }}/httpd.conf"
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,16 +17,23 @@
 # Setup/install tasks.
 - include_tasks: "setup-{{ ansible_os_family }}.yml"
 
+- name: Find Apache daemon binary
+  stat:
+    path: "{{ item }}"
+  with_items: "{{ apache_daemon | list }}"
+  register: apache_daemon_stat
+
 # Figure out what version of Apache is installed.
 - name: Get installed version of Apache.
-  command: "{{ apache_daemon_path }}{{ apache_daemon }} -v"
+  command: "{{ item }} -v"
+  with_items: "{{ apache_daemon_stat.results | selectattr('stat.exists') | map(attribute='item') | first }}"
   changed_when: false
   check_mode: false
   register: _apache_version
 
 - name: Create apache_version variable.
   set_fact:
-    apache_version: "{{ _apache_version.stdout.split()[2].split('/')[1] }}"
+    apache_version: "{{ _apache_version.results[0].stdout.split()[2].split('/')[1] }}"
 
 - name: Include Apache 2.2 variables.
   include_vars: apache-22.yml

--- a/vars/AmazonLinux.yml
+++ b/vars/AmazonLinux.yml
@@ -1,7 +1,7 @@
 ---
 apache_service: httpd
-apache_daemon: httpd
-apache_daemon_path: /usr/sbin/
+apache_daemon:
+  - /usr/sbin/httpd
 apache_server_root: /etc/httpd
 apache_conf_path: /etc/httpd/conf.d
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,7 +1,7 @@
 ---
 apache_service: apache2
-apache_daemon: apache2
-apache_daemon_path: /usr/sbin/
+apache_daemon:
+  - /usr/sbin/apache2
 apache_server_root: /etc/apache2
 apache_conf_path: /etc/apache2
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,7 +1,7 @@
 ---
 apache_service: httpd
-apache_daemon: httpd
-apache_daemon_path: /usr/sbin/
+apache_daemon:
+  - /usr/sbin/httpd
 apache_server_root: /etc/httpd
 apache_conf_path: /etc/httpd/conf.d
 

--- a/vars/Solaris.yml
+++ b/vars/Solaris.yml
@@ -1,7 +1,7 @@
 ---
 apache_service: apache24
-apache_daemon: httpd
-apache_daemon_path: /usr/apache2/2.4/bin/
+apache_daemon:
+  - /usr/apache2/2.4/bin/httpd
 apache_server_root: /etc/apache2/2.4/
 apache_conf_path: /etc/apache2/2.4/conf.d
 

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -1,7 +1,8 @@
 ---
 apache_service: apache2
-apache_daemon: httpd2
-apache_daemon_path: /usr/sbin/
+apache_daemon:
+  - /usr/sbin/httpd
+  - /usr/sbin/httpd2
 apache_server_root: /etc/apache2
 apache_conf_path: /etc/apache2/conf.d
 


### PR DESCRIPTION
Hi Jeff,

the Apache role fails on recent (for the last 4 years nearly) SUSEs, because the Apache binary (symlink) was once renamed from `/usr/sbin/httpd2` to `/usr/sbin/httpd`.
This PR changes the `apache_daemon` variable to be a list of potential locations of the apache daemon which are stat'ed one after the other.

Note: I'm neither a Python developer nor a savvy Ansible user. So please test thoroughly.
Note2: I removed variable `apache_daemon_path` completely. The path is now incorporated into the `apache_daemon` variable items, see first commit mesage for details.