### PR TITLE
Update/split ssl from non ssl individual vhosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,8 +6,11 @@ apache_listen_port: 80
 apache_listen_port_ssl: 443
 
 apache_create_vhosts: true
+apache_create_individual_vhosts: false
 apache_vhosts_filename: "vhosts.conf"
+apache_vhost_filename_extension: "vhost.conf"
 apache_vhosts_template: "vhosts.conf.j2"
+apache_vhosts_individual_template: "vhosts.individual.conf.j2"
 
 # On Debian/Ubuntu, a default virtualhost is included in Apache's configuration.
 # Set this to `true` to remove that default.
@@ -30,6 +33,20 @@ apache_vhosts_ssl: []
 # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
 # - servername: "local.dev",
 #   documentroot: "/var/www/html",
+#   certificate_file: "/path/to/certificate.crt",
+#   certificate_key_file: "/path/to/certificate.key",
+#   # Optional.
+#   certificate_chain_file: "/path/to/certificate_chain.crt"
+
+apache_vhosts_individual:
+  # Additional properties:
+  # 'serveradmin, serveralias, allow_override, options, extra_parameters, vhostname, directoryindex'.
+  # vhostname is the name minus the file extension of the vhost file used for this vhost configuration
+  - servername: "local.dev"
+    documentroot: "/var/www/html"
+    vhostname: "vhost"
+# Additional properties (if using SSL):
+# 'certificate_file, certificate_key_file, certificate_chain_file'.
 #   certificate_file: "/path/to/certificate.crt",
 #   certificate_key_file: "/path/to/certificate.key",
 #   # Optional.

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -44,4 +44,4 @@
   with_together:
     - "{{ apache_vhosts_individual }}"
     - "{{ apache_ssl_certificates_individual.results }}"
-  when: apache_create_individual_vhosts
+  when: apache_create_vhosts

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -9,9 +9,19 @@
   notify: restart apache
 
 - name: Check whether certificates defined in vhosts exist.
-  stat: path={{ item.certificate_file }}
+  stat:
+    path: "{{ item.certificate_file }}"
   register: apache_ssl_certificates
   with_items: "{{ apache_vhosts_ssl }}"
+
+- name: Check whether certificates defined in vhosts exist for individual vhost configuration.
+  stat:
+    path: "{{ item.certificate_file }}"
+  register: apache_ssl_certificates_individual
+  when: item.certificate_file is defined
+  with_items: "{{ apache_vhosts_individual }}"
+- debug:
+    var: apache_ssl_certificates_individual
 
 - name: Add apache vhosts configuration.
   template:
@@ -22,3 +32,16 @@
     mode: 0644
   notify: restart apache
   when: apache_create_vhosts
+
+- name: Add apache individual vhosts configuration.
+  template:
+    src: "{{ apache_vhosts_individual_template }}"
+    dest: "{{ apache_conf_path }}/{{ item.0.vhostname }}.{{ apache_vhost_filename_extension }}"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  with_together:
+    - "{{ apache_vhosts_individual }}"
+    - "{{ apache_ssl_certificates_individual.results }}"
+  when: apache_create_individual_vhosts

--- a/tasks/configure-Suse.yml
+++ b/tasks/configure-Suse.yml
@@ -14,9 +14,13 @@
   with_items: "{{ apache_vhosts_ssl }}"
 
 - name: Check whether certificates defined in vhosts exist for individual vhost configuration.
-  stat: path={{ item.certificate_file }}
+  stat:
+    path: "{{ item.certificate_file }}"
   register: apache_ssl_certificates_individual
+  when: item.certificate_file is defined
   with_items: "{{ apache_vhosts_individual }}"
+- debug:
+    var: apache_ssl_certificates_individual
 
 - name: Add apache vhosts configuration.
   template:
@@ -26,4 +30,17 @@
     group: root
     mode: 0644
   notify: restart apache
+  when: apache_create_vhosts
+
+- name: Add apache individual vhosts configuration.
+  template:
+    src: "{{ apache_vhosts_individual_template }}"
+    dest: "{{ apache_conf_path }}/{{ item.0.vhostname }}.{{ apache_vhost_filename_extension }}"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  with_together:
+    - "{{ apache_vhosts_individual }}"
+    - "{{ apache_ssl_certificates_individual.results }}"
   when: apache_create_vhosts

--- a/tasks/configure-Suse.yml
+++ b/tasks/configure-Suse.yml
@@ -13,6 +13,11 @@
   register: apache_ssl_certificates
   with_items: "{{ apache_vhosts_ssl }}"
 
+- name: Check whether certificates defined in vhosts exist for individual vhost configuration.
+  stat: path={{ item.certificate_file }}
+  register: apache_ssl_certificates_individual
+  with_items: "{{ apache_vhosts_individual }}"
+
 - name: Add apache vhosts configuration.
   template:
     src: "{{ apache_vhosts_template }}"

--- a/templates/vhosts.individual.conf.j2
+++ b/templates/vhosts.individual.conf.j2
@@ -1,0 +1,81 @@
+{{ apache_global_vhost_settings }}
+
+{# Set up VirtualHost #}
+<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
+  ServerName {{ item.0.servername }}
+{% if item.0.serveralias is defined %}
+  ServerAlias {{ item.0.serveralias }}
+{% endif %}
+{% if item.0.documentroot is defined %}
+  DocumentRoot "{{ item.0.documentroot }}"
+{% endif %}
+{% if item.0.serveradmin is defined %}
+  ServerAdmin {{ item.0.serveradmin }}
+{% endif %}
+{% if item.0.documentroot is defined %}
+  <Directory "{{ item.0.documentroot }}">
+    AllowOverride {{ item.0.allow_override | default(apache_allow_override) }}
+    Options {{ item.0.options | default(apache_options) }}
+{% if apache_vhosts_version == "2.2" %}
+    Order allow,deny
+    Allow from all
+{% else %}
+    Require all granted
+{% endif %}
+{% if item.0.directoryindex is defined %}
+    DirectoryIndex "{{ item.0.directoryindex }}"
+{% endif %}
+  </Directory>
+{% endif %}
+{% if item.0.extra_parameters is defined %}
+  {{ item.0.extra_parameters }}
+{% endif %}
+</VirtualHost>
+
+{# Set up SSL VirtualHost #}
+{% if item.0.certificate_file is defined %}
+{% if apache_ignore_missing_ssl_certificate or item.1.stat.exists %}
+<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port_ssl }}>
+  ServerName {{ item.0.servername }}
+{% if item.0.serveralias is defined %}
+  ServerAlias {{ item.0.serveralias }}
+{% endif %}
+{% if item.0.documentroot is defined %}
+  DocumentRoot "{{ item.0.documentroot }}"
+{% endif %}
+{% if item.0.serveradmin is defined %}
+  ServerAdmin {{ item.0.serveradmin }}
+{% endif %}
+  SSLEngine on
+  SSLCipherSuite {{ apache_ssl_cipher_suite }}
+  SSLProtocol {{ apache_ssl_protocol }}
+  SSLHonorCipherOrder On
+{% if apache_vhosts_version == "2.4" %}
+  SSLCompression off
+{% endif %}
+  SSLCertificateFile {{ item.0.certificate_file }}
+  SSLCertificateKeyFile {{ item.0.certificate_key_file }}
+{% if item.0.certificate_chain_file is defined %}
+  SSLCertificateChainFile {{ item.0.certificate_chain_file }}
+{% endif %}
+{% if item.0.documentroot is defined %}
+  <Directory "{{ item.0.documentroot }}">
+    AllowOverride {{ item.0.allow_override | default(apache_allow_override) }}
+    Options {{ item.0.options | default(apache_options) }}
+{% if apache_vhosts_version == "2.2" %}
+    Order allow,deny
+    Allow from all
+{% else %}
+    Require all granted
+{% endif %}
+{% if item.0.directoryindex is defined %}
+    DirectoryIndex "{{ item.0.directoryindex }}"
+{% endif %}
+  </Directory>
+{% endif %}
+{% if item.0.extra_parameters is defined %}
+  {{ item.0.extra_parameters }}
+{% endif %}
+</VirtualHost>
+{% endif %}
+{% endif %}

--- a/templates/vhosts.individual.conf.j2
+++ b/templates/vhosts.individual.conf.j2
@@ -1,6 +1,7 @@
 {{ apache_global_vhost_settings }}
 
 {# Set up VirtualHost #}
+{% if item.0.certificate_file is not defined %}
 <VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
   ServerName {{ item.0.servername }}
 {% if item.0.serveralias is defined %}
@@ -31,6 +32,7 @@
   {{ item.0.extra_parameters }}
 {% endif %}
 </VirtualHost>
+{% endif %}
 
 {# Set up SSL VirtualHost #}
 {% if item.0.certificate_file is defined %}


### PR DESCRIPTION
Updated role to split ssl from non ssl individual vhosts.
Also removed reference to apache_create_individual_vhosts as this flag was redundant.  Instead tasks that were using that flag now use apache_create_vhosts flag.
Roles updated for Redhat and Suse. 