### PR TITLE
Add Support for Amazon Linux 2

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,12 @@
   include_vars: "AmazonLinux.yml"
   when:
     - ansible_distribution == "Amazon"
+    - ansible_distribution_major_version == "2018"
+
+- name: Include variables for Amazon Linux 2.
+  include_vars: "AmazonLinux2.yml"
+  when:
+    - ansible_distribution == "Amazon"
     - ansible_distribution_major_version == "NA"
 
 - name: Define apache_packages.

--- a/vars/AmazonLinux2.yml
+++ b/vars/AmazonLinux2.yml
@@ -1,0 +1,18 @@
+---
+apache_service: httpd
+apache_daemon: httpd
+apache_daemon_path: /usr/sbin/
+apache_server_root: /etc/httpd
+apache_conf_path: /etc/httpd/conf.d
+
+apache_vhosts_version: "2.4"
+
+__apache_packages:
+  - httpd
+  - httpd-devel
+  - mod_ssl
+  - openssh
+
+apache_ports_configuration_items:
+  - regexp: "^Listen "
+    line: "Listen {{ apache_listen_port }}"


### PR DESCRIPTION
Applying the role onto Amazon Linux release 2 (Karoo) causes ansible to attempt to install the wrong package names (httpd24 & httpd24-devel). Added some logic in tasks/main.yml to differentiate between the Amazon Linux versions and a new vars file to use.