### PR TITLE
Allow alternate ports on hosts with SELinux enabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
     state: present
   when:
     - ansible_selinux is defined
-    - ansible_selinux != ""
+    - ansible_selinux
     - ansible_selinux.status == "enabled"
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,21 @@
 # Setup/install tasks.
 - include_tasks: "setup-{{ ansible_os_family }}.yml"
 
+# Make sure selinux allows us to use the configured ports.  We know it is 
+# enabled if the ansible_selinux fact is defined, has a value, and its status
+# is "enabled".
+- name: Configure SELinux to allow Apache to listen on http and https ports.
+  seport:
+    ports: "{{ apache_listen_port }},{{ apache_listen_port_ssl }}"
+    proto: tcp
+    setype: http_port_t
+    state: present
+  when: 
+    - ansible_selinux is defined
+    - ansible_selinux
+    - ansible_selinux.status == "enabled"
+
+
 # Figure out what version of Apache is installed.
 - name: Get installed version of Apache.
   command: "{{ apache_daemon_path }}{{ apache_daemon }} -v"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
     state: present
   when:
     - ansible_selinux is defined
-    - ansible_selinux
+    - ansible_selinux != ""
     - ansible_selinux.status == "enabled"
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 # Setup/install tasks.
 - include_tasks: "setup-{{ ansible_os_family }}.yml"
 
-# Make sure selinux allows us to use the configured ports.  We know it is 
+# Make sure selinux allows us to use the configured ports.  We know it is
 # enabled if the ansible_selinux fact is defined, has a value, and its status
 # is "enabled".
 - name: Configure SELinux to allow Apache to listen on http and https ports.
@@ -26,7 +26,7 @@
     proto: tcp
     setype: http_port_t
     state: present
-  when: 
+  when:
     - ansible_selinux is defined
     - ansible_selinux
     - ansible_selinux.status == "enabled"


### PR DESCRIPTION
This role allows users to change the ports Apache uses, but this causes failures on hosts that use SELinux, where only the default ports are opened with the installation of the httpd package.  We need an additional task to tell SELinux about the ports 

Using a pre_task before including the apache role won't work because the SELinux type won't exist until after the httpd package is installed.

Using a post_task after including the role also won't work because Apache won't restart properly when the role handler fires (at least that was the behavior I observed - the role's handler was firing before my task ran).

So I added a task to the role itself, which takes care of the problem.  The molecule tests still pass, and FWIW, the role appears to work perfectly in CentOS 8 servers.