### PR TITLE
Splits vhosts config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,15 @@ The default values for the `AllowOverride` and `Options` directives for the `doc
       - rewrite.load
       - ssl.load
     apache_mods_disabled: []
+    apache_mods_config:
+      mpm_prefork: |
+        StartServers     3
+        MinSpareServers  3
+        MaxSpareServers  5
+        MaxRequestWorkers 25
+        MaxConnectionsPerChild   1024
 
-(Debian/Ubuntu ONLY) Which Apache mods to enable or disable (these will be symlinked into the appropriate location). See the `mods-available` directory inside the apache configuration directory (`/etc/apache2/mods-available` by default) for all the available mods.
+(Debian/Ubuntu ONLY) Which Apache mods to enable or disable (these will be symlinked into the appropriate location). See the `mods-available` directory inside the apache configuration directory (`/etc/apache2/mods-available` by default) for all the available mods. `apache_mods_config` entries will be converted into conf files (under `/etc/apache2/mods-available/` by default). The contents will be wrapped in `<IfModule>` statements.
 
     apache_packages:
       - [platform-specific]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ apache_listen_port_ssl: 443
 apache_create_vhosts: true
 apache_vhosts_filename: "vhosts.conf"
 apache_vhosts_template: "vhosts.conf.j2"
+apache_vhosts_separate_files: false
 
 # On Debian/Ubuntu, a default virtualhost is included in Apache's configuration.
 # Set this to `true` to remove that default.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,8 @@ apache_mods_enabled:
   - ssl.load
 apache_mods_disabled: []
 
+apache_mods_config: {}
+
 # Set initial apache state. Recommended values: `started` or `stopped`
 apache_state: started
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,9 +25,6 @@ galaxy_info:
         - trusty
         - xenial
         - bionic
-    - name: Suse
-      versions:
-        - all
     - name: Solaris
       versions:
         - 11.3

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -41,7 +41,7 @@
   register: apache_ssl_certificates
   with_items: "{{ apache_vhosts_ssl }}"
 
-- name: Add apache vhosts configuration.
+- name: Add apache vhosts single configuration file.
   template:
     src: "{{ apache_vhosts_template }}"
     dest: "{{ apache_conf_path }}/sites-available/{{ apache_vhosts_filename }}"
@@ -49,7 +49,9 @@
     group: root
     mode: 0644
   notify: restart apache
-  when: apache_create_vhosts
+  when:
+    - apache_create_vhosts
+    - not apache_vhosts_separate_files
 
 - name: Add vhost symlink in sites-enabled.
   file:
@@ -57,7 +59,50 @@
     dest: "{{ apache_conf_path }}/sites-enabled/{{ apache_vhosts_filename }}"
     state: link
   notify: restart apache
-  when: apache_create_vhosts
+  when:
+    - apache_create_vhosts
+    - not apache_vhosts_separate_files
+
+- name: Add apache vhosts configurations.
+  template:
+    src: vhosts-hosts.conf.j2
+    dest: "{{ apache_conf_path }}/sites-available/{{ vhost.servername }}.conf"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  with_items: "{{ apache_vhosts }}"
+  loop_control:
+    loop_var: vhost
+  when:
+    - apache_create_vhosts
+    - apache_vhosts_separate_files
+
+- name: Add apache ssl vhosts configurations.
+  template:
+    src: vhosts-ssl-hosts.conf.j2
+    dest: "{{ apache_conf_path }}/sites-available/{{ vhost.servername }}.conf"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  with_items: "{{ apache_vhosts_ssl }}"
+  loop_control:
+    loop_var: vhost
+  when:
+    - apache_create_vhosts
+    - apache_vhosts_separate_files
+
+- name: Add vhost symlinks in sites-enabled.
+  file:
+    src: "{{ apache_conf_path }}/sites-available/{{ item.servername }}.conf"
+    dest: "{{ apache_conf_path }}/sites-enabled/{{ item.servername }}.conf"
+    state: link
+  notify: restart apache
+  with_items: "{{ apache_vhosts + apache_vhosts_ssl }}"
+  when:
+    - apache_create_vhosts
+    - apache_vhosts_separate_files
 
 - name: Remove default vhost in sites-enabled.
   file:

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -23,6 +23,19 @@
   with_items: "{{ apache_mods_disabled }}"
   notify: restart apache
 
+- name: Configure Apache mods.
+  copy:
+    content: >
+      <IfModule {{ item.key }}_module>
+        {{ item.value }}
+      </IfModule>
+    dest: "{{ apache_server_root }}/mods-available/{{ item.key }}.conf"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  with_dict: "{{ apache_mods_config }}"
+
 - name: Check whether certificates defined in vhosts exist.
   stat: "path={{ item.certificate_file }}"
   register: apache_ssl_certificates

--- a/templates/vhosts-global.conf.j2
+++ b/templates/vhosts-global.conf.j2
@@ -1,0 +1,1 @@
+{{ apache_global_vhost_settings }}

--- a/templates/vhosts-hosts.conf.j2
+++ b/templates/vhosts-hosts.conf.j2
@@ -1,0 +1,28 @@
+<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
+  ServerName {{ vhost.servername }}
+{% if vhost.serveralias is defined %}
+  ServerAlias {{ vhost.serveralias }}
+{% endif %}
+{% if vhost.documentroot is defined %}
+  DocumentRoot "{{ vhost.documentroot }}"
+{% endif %}
+
+{% if vhost.serveradmin is defined %}
+  ServerAdmin {{ vhost.serveradmin }}
+{% endif %}
+{% if vhost.documentroot is defined %}
+  <Directory "{{ vhost.documentroot }}">
+    AllowOverride {{ vhost.allow_override | default(apache_allow_override) }}
+    Options {{ vhost.options | default(apache_options) }}
+{% if apache_vhosts_version == "2.2" %}
+    Order allow,deny
+    Allow from all
+{% else %}
+    Require all granted
+{% endif %}
+  </Directory>
+{% endif %}
+{% if vhost.extra_parameters is defined %}
+  {{ vhost.extra_parameters }}
+{% endif %}
+</VirtualHost>

--- a/templates/vhosts-ssl-hosts.conf.j2
+++ b/templates/vhosts-ssl-hosts.conf.j2
@@ -1,0 +1,46 @@
+{% if apache_ignore_missing_ssl_certificate or
+apache_ssl_certificates.results[loop.index0].stat.exists %}
+<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port_ssl }}>
+  ServerName {{ vhost.servername }}
+{% if vhost.serveralias is defined %}
+  ServerAlias {{ vhost.serveralias }}
+{% endif %}
+{% if vhost.documentroot is defined %}
+  DocumentRoot "{{ vhost.documentroot }}"
+{% endif %}
+
+  SSLEngine on
+  SSLCipherSuite {{ apache_ssl_cipher_suite }}
+  SSLProtocol {{ apache_ssl_protocol }}
+  SSLHonorCipherOrder On
+{% if apache_vhosts_version == "2.4" %}
+  SSLCompression off
+{% endif %}
+  SSLCertificateFile {{ vhost.certificate_file }}
+  SSLCertificateKeyFile {{ vhost.certificate_key_file }}
+{% if vhost.certificate_chain_file is defined %}
+  SSLCertificateChainFile {{ vhost.certificate_chain_file }}
+{% endif %}
+
+{% if vhost.serveradmin is defined %}
+  ServerAdmin {{ vhost.serveradmin }}
+{% endif %}
+{% if vhost.documentroot is defined %}
+  <Directory "{{ vhost.documentroot }}">
+    AllowOverride {{ vhost.allow_override | default(apache_allow_override) }}
+    Options {{ vhost.options | default(apache_options) }}
+{% if apache_vhosts_version == "2.2" %}
+    Order allow,deny
+    Allow from all
+{% else %}
+    Require all granted
+{% endif %}
+  </Directory>
+{% endif %}
+{% if vhost.extra_parameters is defined %}
+  {{ vhost.extra_parameters }}
+{% endif %}
+</VirtualHost>
+
+{% endif %}
+

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -1,82 +1,9 @@
-{{ apache_global_vhost_settings }}
-
 {# Set up VirtualHosts #}
 {% for vhost in apache_vhosts %}
-<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
-  ServerName {{ vhost.servername }}
-{% if vhost.serveralias is defined %}
-  ServerAlias {{ vhost.serveralias }}
-{% endif %}
-{% if vhost.documentroot is defined %}
-  DocumentRoot "{{ vhost.documentroot }}"
-{% endif %}
-
-{% if vhost.serveradmin is defined %}
-  ServerAdmin {{ vhost.serveradmin }}
-{% endif %}
-{% if vhost.documentroot is defined %}
-  <Directory "{{ vhost.documentroot }}">
-    AllowOverride {{ vhost.allow_override | default(apache_allow_override) }}
-    Options {{ vhost.options | default(apache_options) }}
-{% if apache_vhosts_version == "2.2" %}
-    Order allow,deny
-    Allow from all
-{% else %}
-    Require all granted
-{% endif %}
-  </Directory>
-{% endif %}
-{% if vhost.extra_parameters is defined %}
-  {{ vhost.extra_parameters }}
-{% endif %}
-</VirtualHost>
-
+  {% include './vhosts-hosts.conf.j2' %}
 {% endfor %}
 
 {# Set up SSL VirtualHosts #}
 {% for vhost in apache_vhosts_ssl %}
-{% if apache_ignore_missing_ssl_certificate or apache_ssl_certificates.results[loop.index0].stat.exists %}
-<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port_ssl }}>
-  ServerName {{ vhost.servername }}
-{% if vhost.serveralias is defined %}
-  ServerAlias {{ vhost.serveralias }}
-{% endif %}
-{% if vhost.documentroot is defined %}
-  DocumentRoot "{{ vhost.documentroot }}"
-{% endif %}
-
-  SSLEngine on
-  SSLCipherSuite {{ apache_ssl_cipher_suite }}
-  SSLProtocol {{ apache_ssl_protocol }}
-  SSLHonorCipherOrder On
-{% if apache_vhosts_version == "2.4" %}
-  SSLCompression off
-{% endif %}
-  SSLCertificateFile {{ vhost.certificate_file }}
-  SSLCertificateKeyFile {{ vhost.certificate_key_file }}
-{% if vhost.certificate_chain_file is defined %}
-  SSLCertificateChainFile {{ vhost.certificate_chain_file }}
-{% endif %}
-
-{% if vhost.serveradmin is defined %}
-  ServerAdmin {{ vhost.serveradmin }}
-{% endif %}
-{% if vhost.documentroot is defined %}
-  <Directory "{{ vhost.documentroot }}">
-    AllowOverride {{ vhost.allow_override | default(apache_allow_override) }}
-    Options {{ vhost.options | default(apache_options) }}
-{% if apache_vhosts_version == "2.2" %}
-    Order allow,deny
-    Allow from all
-{% else %}
-    Require all granted
-{% endif %}
-  </Directory>
-{% endif %}
-{% if vhost.extra_parameters is defined %}
-  {{ vhost.extra_parameters }}
-{% endif %}
-</VirtualHost>
-
-{% endif %}
+  {% include './vhosts-ssl-hosts.conf.j2' %}
 {% endfor %}


### PR DESCRIPTION
This PR allows the users to have a single vhost config file per virtual host. 

My use case is that I do not define a single, hardcoded `apache_vhosts` list, but I construct it dynamically by reading other variables. I use a bash script to drive ansible and to load the var files I need each time. It can happen that some of the `vhosts` variables are not available for some run of the bash script, eg because I purposefully omitted them via arguments to the bash script to speed things up. In this case, the single vhosts config will be overwritten and will contain the limited set of vhosts of that current bash script run instead of all the vhosts I want to have configured.