### PR TITLE
bugfix: apply settings defined in var `apache_ssl_protocol`

### DIFF
--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -8,6 +8,22 @@
   with_items: "{{ apache_ports_configuration_items }}"
   notify: restart apache
 
+- name: Apply ssl_protocol config in the global ssl.conf
+  lineinfile:
+    dest: "{{ apache_conf_path }}/ssl.conf"
+    regexp: ^SSLProtocol
+    line: "SSLProtocol {{ apache_ssl_protocol }}"
+    state: present
+  notify: restart apache
+
+- name: Apply apache_ssl_cipher_suite config in the global ssl.conf
+  lineinfile:
+    dest: "{{ apache_conf_path }}/ssl.conf"
+    regexp: ^SSLCipherSuite
+    line: "SSLCipherSuite {{ apache_ssl_cipher_suite }}"
+    state: present
+  notify: restart apache
+
 - name: Check whether certificates defined in vhosts exist.
   stat: path={{ item.certificate_file }}
   register: apache_ssl_certificates


### PR DESCRIPTION
I tried to disable TLS 1.0 and TLS 1.1 using variable `apache_ssl_protocol` in this role but it was not working. Contents of `apache_ssl_protocol` are populated to `/etc/httpd/conf.d/vhosts.conf` but not applied. I was always getting a warning `This server supports TLS 1.0 and TLS 1.1. Grade will be capped to B from January 2020` in the ssl check in [https://www.ssllabs.com](https://www.ssllabs.com). e.g.

![ssl_check](https://i.imgur.com/Rlp79sf.png)

I was also getting these results with nmap:

```
 nmap --script ssl-enum-ciphers -p 443 web_server_hostname | grep TLSv
|   TLSv1.0: 
|   TLSv1.1: 
|   TLSv1.2: 
```

I realized that even if the settings are defined in `vhosts.conf` the global settings from `/etc/httpd/conf.d/ssl.conf` are applied as described here: https://serverfault.com/a/848187

This PR workarounds the problem by also applying the settings defined in vars `apache_ssl_protocol` and `apache_ssl_cipher_suite` to `/etc/httpd/conf.d/ssl.conf`

After this workaround I get this with nmap:
```
 nmap --script ssl-enum-ciphers -p 443 web_server_hostname | grep TLSv
|   TLSv1.2: 
```

I have tested it in centos7