### PR TITLE
Principle of Least Privilege applied to ansible

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: restart apache
+  become: True
   service:
     name: "{{ apache_service }}"
     state: "{{ apache_restart_state }}"

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -1,5 +1,6 @@
 ---
 - name: Configure Apache.
+  become: True
   lineinfile:
     dest: "{{ apache_server_root }}/ports.conf"
     regexp: "{{ item.regexp }}"
@@ -9,6 +10,7 @@
   notify: restart apache
 
 - name: Enable Apache mods.
+  become: True
   file:
     src: "{{ apache_server_root }}/mods-available/{{ item }}"
     dest: "{{ apache_server_root }}/mods-enabled/{{ item }}"
@@ -17,6 +19,7 @@
   notify: restart apache
 
 - name: Disable Apache mods.
+  become: True
   file:
     path: "{{ apache_server_root }}/mods-enabled/{{ item }}"
     state: absent
@@ -29,6 +32,7 @@
   with_items: "{{ apache_vhosts_ssl }}"
 
 - name: Add apache vhosts configuration.
+  become: True
   template:
     src: "{{ apache_vhosts_template }}"
     dest: "{{ apache_conf_path }}/sites-available/{{ apache_vhosts_filename }}"

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -1,5 +1,6 @@
 ---
 - name: Configure Apache.
+  become: True
   lineinfile:
     dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
     regexp: "{{ item.regexp }}"
@@ -14,6 +15,7 @@
   with_items: "{{ apache_vhosts_ssl }}"
 
 - name: Add apache vhosts configuration.
+  become: True
   template:
     src: "{{ apache_vhosts_template }}"
     dest: "{{ apache_conf_path }}/{{ apache_vhosts_filename }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,7 @@
   include_tasks: "configure-{{ ansible_os_family }}.yml"
 
 - name: Ensure Apache has selected state and enabled on boot.
+  become: True
   service:
     name: "{{ apache_service }}"
     state: "{{ apache_state }}"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,5 +1,6 @@
 ---
 - name: Ensure Apache is installed on RHEL.
+  become: True
   package:
     name: "{{ apache_packages }}"
     state: "{{ apache_packages_state }}"


### PR DESCRIPTION
Only use become for tasks that need it instead of giving to the whole role or playbook.

Only tested/check for the setup I'm using so other tasks might also need to be changed, or having become removed from. Which was Vagrant, VirtualBox and Centos 7.