### PR TITLE
Use hostname as default servername for /var/www/html

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ apache_global_vhost_settings: |
 apache_vhosts:
   # Additional properties:
   # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
-  - servername: "local.dev"
+  - servername: "{{ inventory_hostname }}"
     documentroot: "/var/www/html"
 
 apache_allow_override: "All"


### PR DESCRIPTION
IMO when having a system with multiple nodes reachable by hostname it makes more sense to setup the default vhost to the machine its hostname instead of `local.dev` (allows for easier testing).