### PR TITLE
Adding support for drop-in configuration on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ The default values for the `AllowOverride` and `Options` directives for the `doc
 
 (Debian/Ubuntu ONLY) Which Apache mods to enable or disable (these will be symlinked into the appropriate location). See the `mods-available` directory inside the apache configuration directory (`/etc/apache2/mods-available` by default) for all the available mods.
 
+    apache_conf_enabled: []
+    apache_conf_disabled:
+      - serve-cgi-bin.conf
+
+(Debian/Ubuntu ONLY) Which Apache conf to enable or disable (these will be symlinked into the appropriate location). See the `conf-available` directory inside the apache configuration directory (`/etc/apache2/conf-available` by default) for all the available drop-in configurations.
+
     apache_packages:
       - [platform-specific]
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,6 +45,9 @@ apache_mods_enabled:
   - rewrite.load
   - ssl.load
 apache_mods_disabled: []
+apache_conf_enabled: []
+apache_conf_disabled: []
+
 
 # Set initial apache state. Recommended values: `started` or `stopped`
 apache_state: started

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -23,6 +23,21 @@
   with_items: "{{ apache_mods_disabled }}"
   notify: restart apache
 
+- name: Enable Apache configuration drop-ins.
+  file:
+    src: "{{ apache_server_root }}/conf-available/{{ item }}"
+    dest: "{{ apache_server_root }}/conf-enabled/{{ item }}"
+    state: link
+  with_items: "{{ apache_conf_enabled }}"
+  notify: restart apache
+
+- name: Disable Apache configuration drop-ins.
+  file:
+    path: "{{ apache_server_root }}/conf-enabled/{{ item }}"
+    state: absent
+  with_items: "{{ apache_conf_disabled }}"
+  notify: restart apache
+
 - name: Check whether certificates defined in vhosts exist.
   stat: "path={{ item.certificate_file }}"
   register: apache_ssl_certificates


### PR DESCRIPTION
Debian and Ubuntu have drop-in directories for configuration supplied by third-party packages. This merge allows for them to be enabled or disabled.