### PR TITLE
Fix vhosts extra_parameters indentation

### DIFF
--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -27,7 +27,7 @@
   </Directory>
 {% endif %}
 {% if vhost.extra_parameters is defined %}
-  {{ vhost.extra_parameters }}
+{{ vhost.extra_parameters | indent(width=2, first=True, indentfirst=True) }}
 {% endif %}
 </VirtualHost>
 
@@ -74,7 +74,7 @@
   </Directory>
 {% endif %}
 {% if vhost.extra_parameters is defined %}
-  {{ vhost.extra_parameters }}
+{{ vhost.extra_parameters | indent(width=2, first=True, indentfirst=True) }}
 {% endif %}
 </VirtualHost>
 


### PR DESCRIPTION
Uses the [indent](https://jinja.palletsprojects.com/en/2.11.x/templates/#indent) Jinja filter to ensure that all lines of the extra_parameters variable are indented to the same level (2 to match the rest of the vhosts template)

Example playbook snippet:

```yaml
- name: Example play
  become: true
  vars:
    apache_vhosts:
      - servername: example.com
        extra_parameters: |
          Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
          Header always set X-Content-Type-Options: "nosniff"
          Header always set X-Frame-Options: "SAMEORIGIN"
```

Would previously produce this output:
```
<VirtualHost *:80>
  ServerName example.com

  Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
Header always set X-Content-Type-Options: "nosniff"
Header always set X-Frame-Options: "SAMEORIGIN"

</VirtualHost>
```

With this change the output is:
```
<VirtualHost *:80>
  ServerName example.com

  Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
  Header always set X-Content-Type-Options: "nosniff"
  Header always set X-Frame-Options: "SAMEORIGIN"

</VirtualHost>

```

I added `first` and `indentfirst` keyword arguments to cover all bases (`indentfirst` was renamed to `first` in Jinja 2.10). 