### PR TITLE
Simplify the vhost template

### DIFF
--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -7,14 +7,12 @@
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
-{% if vhost.documentroot is defined %}
-  DocumentRoot "{{ vhost.documentroot }}"
-{% endif %}
-
 {% if vhost.serveradmin is defined %}
   ServerAdmin {{ vhost.serveradmin }}
 {% endif %}
+
 {% if vhost.documentroot is defined %}
+  DocumentRoot "{{ vhost.documentroot }}"
   <Directory "{{ vhost.documentroot }}">
     AllowOverride {{ vhost.allow_override | default(apache_allow_override) }}
     Options {{ vhost.options | default(apache_options) }}
@@ -26,9 +24,8 @@
 {% endif %}
   </Directory>
 {% endif %}
-{% if vhost.extra_parameters is defined %}
-  {{ vhost.extra_parameters }}
-{% endif %}
+
+  {{ vhost.extra_parameters | default("") | indent(2) }}
 </VirtualHost>
 
 {% endfor %}
@@ -41,8 +38,8 @@
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
-{% if vhost.documentroot is defined %}
-  DocumentRoot "{{ vhost.documentroot }}"
+{% if vhost.serveradmin is defined %}
+  ServerAdmin {{ vhost.serveradmin }}
 {% endif %}
 
   SSLEngine on
@@ -58,10 +55,8 @@
   SSLCertificateChainFile {{ vhost.certificate_chain_file }}
 {% endif %}
 
-{% if vhost.serveradmin is defined %}
-  ServerAdmin {{ vhost.serveradmin }}
-{% endif %}
 {% if vhost.documentroot is defined %}
+  DocumentRoot "{{ vhost.documentroot }}"
   <Directory "{{ vhost.documentroot }}">
     AllowOverride {{ vhost.allow_override | default(apache_allow_override) }}
     Options {{ vhost.options | default(apache_options) }}
@@ -73,9 +68,8 @@
 {% endif %}
   </Directory>
 {% endif %}
-{% if vhost.extra_parameters is defined %}
-  {{ vhost.extra_parameters }}
-{% endif %}
+
+  {{ vhost.extra_parameters | default("") | indent(2) }}
 </VirtualHost>
 
 {% endif %}


### PR DESCRIPTION
This commit removes a redundant test for `vhost.documentroot` by moving the `DocumentRoot` line directly above `<Directory>`, which already has the same test.

This commit also simplifies the test if `vhost.extra_parameters` is undefined by using a jinja2 filter. To make the generated file look nicer and more consistent, I indented the result of expanding `vhost.extra_parameters`.

This change makes no semantic difference to the generated file.