### PR TITLE
✨ Adds `apache_vhosts.directory` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ You can add or override global Apache configuration settings in the role-provide
       # Additional optional properties: 'serveradmin, serveralias, extra_parameters'.
       - servername: "local.dev"
         documentroot: "/var/www/html"
+        directory: "/var/www/html"
 
 Add a set of properties per virtualhost, including `servername` (required), `documentroot` (required), `allow_override` (optional: defaults to the value of `apache_allow_override`), `options` (optional: defaults to the value of `apache_options`), `serveradmin` (optional), `serveralias` (optional) and `extra_parameters` (optional: you can add whatever additional configuration lines you'd like in here).
 
@@ -52,6 +53,7 @@ Here's an example using `extra_parameters` to add a RewriteRule to redirect all 
       - servername: "www.local.dev"
         serveralias: "local.dev"
         documentroot: "/var/www/html"
+        directory: "/var/www/html"
         extra_parameters: |
           RewriteCond %{HTTP_HOST} !^www\. [NC]
           RewriteRule ^(.*)$ http://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ apache_vhosts:
   # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
   - servername: "local.dev"
     documentroot: "/var/www/html"
+    directory: "/var/www/html"
 
 apache_allow_override: "All"
 apache_options: "-Indexes +FollowSymLinks"

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -14,8 +14,8 @@
 {% if vhost.serveradmin is defined %}
   ServerAdmin {{ vhost.serveradmin }}
 {% endif %}
-{% if vhost.documentroot is defined %}
-  <Directory "{{ vhost.documentroot }}">
+{% if vhost.directory is defined or vhost.documentroot is defined %}
+  <Directory "{{ vhost.directory | default(vhost.documentroot) }}">
     AllowOverride {{ vhost.allow_override | default(apache_allow_override) }}
     Options {{ vhost.options | default(apache_options) }}
 {% if apache_vhosts_version == "2.2" %}
@@ -61,8 +61,8 @@
 {% if vhost.serveradmin is defined %}
   ServerAdmin {{ vhost.serveradmin }}
 {% endif %}
-{% if vhost.documentroot is defined %}
-  <Directory "{{ vhost.documentroot }}">
+{% if vhost.directory is defined or vhost.documentroot is defined %}
+  <Directory "{{ vhost.directory | default(vhost.documentroot) }}">
     AllowOverride {{ vhost.allow_override | default(apache_allow_override) }}
     Options {{ vhost.options | default(apache_options) }}
 {% if apache_vhosts_version == "2.2" %}


### PR DESCRIPTION
Some web frameworks separate the main web root folder from the document root. [Laravel](https://laravel.com/docs/8.x/installation#public-directory), for example, needs the document root to exist in the `./public/` subdirectory (e.g., `/var/www/html/public/`), but Apache still needs the various `<Directory>` directives to apply to the entire `/var/www/html/` directory.

Thus, this idea to separate the variable `documentroot` into two variables instead of having the same variable apply to both `DocumentRoot` and `<Directory>`.
