### PR TITLE
✨ Adds `directory_extras` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can add or override global Apache configuration settings in the role-provide
       - servername: "local.dev"
         documentroot: "/var/www/html"
 
-Add a set of properties per virtualhost, including `servername` (required), `documentroot` (required), `allow_override` (optional: defaults to the value of `apache_allow_override`), `options` (optional: defaults to the value of `apache_options`), `serveradmin` (optional), `serveralias` (optional) and `extra_parameters` (optional: you can add whatever additional configuration lines you'd like in here).
+Add a set of properties per virtualhost, including `servername` (required), `documentroot` (required), `allow_override` (optional: defaults to the value of `apache_allow_override`), `options` (optional: defaults to the value of `apache_options`), `serveradmin` (optional), `serveralias` (optional), `extra_parameters`, and `directory_extras` (both optional: you can add whatever additional configuration lines you'd like in here).
 
 Here's an example using `extra_parameters` to add a RewriteRule to redirect all requests to the `www.` site:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ apache_global_vhost_settings: |
 
 apache_vhosts:
   # Additional properties:
-  # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
+  # 'serveradmin, serveralias, allow_override, options, extra_parameters, directory_extras'.
   - servername: "local.dev"
     documentroot: "/var/www/html"
 
@@ -27,7 +27,7 @@ apache_options: "-Indexes +FollowSymLinks"
 
 apache_vhosts_ssl: []
 # Additional properties:
-# 'serveradmin, serveralias, allow_override, options, extra_parameters'.
+# 'serveradmin, serveralias, allow_override, options, extra_parameters, directory_extras'.
 # - servername: "local.dev",
 #   documentroot: "/var/www/html",
 #   certificate_file: "/path/to/certificate.crt",

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -24,6 +24,7 @@
 {% else %}
     Require all granted
 {% endif %}
+    {{ vhost.directory_extras | default("") | indent(4) }}
   </Directory>
 {% endif %}
 {% if vhost.extra_parameters is defined %}
@@ -71,6 +72,7 @@
 {% else %}
     Require all granted
 {% endif %}
+    {{ vhost.directory_extras | default("") | indent(4) }}
   </Directory>
 {% endif %}
 {% if vhost.extra_parameters is defined %}


### PR DESCRIPTION
Some web apps require additional information be placed in the `<Directory>` section of the vhosts file (i.e., they won't work _outside_ of this section).

For example, [Redmine](https://www.redmine.org/projects/redmine/wiki/howto_configure_apache_to_run_redmine#Ubuntu-Server-Version-This-not-dont-work-for-804-LTS) requires `RailsBaseURI` and `Passenger…` directives in the `<Directory>` section.

This PR aims to allow those additional directives to be placed there.
