### PR TITLE
Correct the mod_php package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An Ansible Role that installs Apache 2.x on RHEL/CentOS, Debian/Ubuntu, SLES and
 
 If you are using SSL/TLS, you will need to provide your own certificate and key files. You can generate a self-signed certificate with a command like `openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout example.key -out example.crt`.
 
-If you are using Apache with PHP, I recommend using the `geerlingguy.php` role to install PHP, and you can either use mod_php (by adding the proper package, e.g. `libapache2-mod-php5` for Ubuntu, to `php_packages`), or by also using `geerlingguy.apache-php-fpm` to connect Apache to PHP via FPM. See that role's README for more info.
+If you are using Apache with PHP, I recommend using the `geerlingguy.php` role to install PHP, and you can either use mod_php (by adding the proper package, e.g. `libapache2-mod-php` for Ubuntu, to `php_packages`), or by also using `geerlingguy.apache-php-fpm` to connect Apache to PHP via FPM. See that role's README for more info.
 
 ## Role Variables
 


### PR DESCRIPTION
The correct mod_php package name for Debian/Ubuntu is libapache2-mod-php:
- Ubuntu: https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libapache2-mod-php&searchon=names
- Debian: https://packages.debian.org/search?suite=stable&section=all&arch=any&searchon=names&keywords=libapache2-mod-php