### PR TITLE
vhost proxy support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,5 @@ jobs:
         run: >-
           ansible-galaxy role import
            --api-key ${{ secrets.GALAXY_API_KEY }}
-           $(echo $GITHUB_REPOSITORY | cut -d/ -f1)
-           $(echo $GITHUB_REPOSITORY | cut -d/ -f2)
+           $(echo ${{ github.repository }} | cut -d/ -f1)
+           $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,4 @@ jobs:
         run: pip3 install ansible-base
 
       - name: Trigger a new import on Galaxy.
-        run: >-
-          ansible-galaxy role import
-           --api-key ${{ secrets.GALAXY_API_KEY }}
-           $(echo ${{ github.repository }} | cut -d/ -f1)
-           $(echo ${{ github.repository }} | cut -d/ -f2)
+        run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,9 @@
 
 name: Release
 'on':
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - '*'
 
 defaults:
   run:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,11 @@ apache_vhosts:
 apache_allow_override: "All"
 apache_options: "-Indexes +FollowSymLinks"
 
+# http proxy properties
+apache_vhost_proxy_balancer_name: "myset"
+apache_vhost_proxy_lbmethod: "bytraffic"
+apache_vhost_proxy_path: ""
+
 apache_vhosts_ssl: []
 # Additional properties:
 # 'serveradmin, serveralias, allow_override, options, extra_parameters'.

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -26,6 +26,24 @@
 {% endif %}
   </Directory>
 {% endif %}
+
+{% if vhost.proxy is defined %}
+  {{ "Setup Proxies" | comment }}
+{% if vhost.proxy.members is defined %}
+  <Proxy "balancer://{{ vhost.proxy.balancername | default(apache_vhost_proxy_balancer_name) }}">
+{% for pmember in vhost.proxy.members %}
+    BalancerMember {{ pmember.host }}
+{% endfor %}
+    ProxySet lbmethod={{ vhost.proxy.lbmethod | default(apache_vhost_proxy_lbmethod) }}
+  </Proxy>
+  ProxyPass "/{{ vhost.proxy.path | default(apache_vhost_proxy_path) }}"  "balancer://{{ vhost.proxy.balancername | default(apache_vhost_proxy_balancer_name) }}/"
+  ProxyPassReverse "/{{ vhost.proxy.path | default(apache_vhost_proxy_path) }}"  "balancer://{{ vhost.proxy.balancername | default(apache_vhost_proxy_balancer_name) }}/"
+{% else %}
+  ProxyPass "/{{ vhost.proxy.path | default(apache_vhost_proxy_path) }}"  "{{ vhost.proxy.host }}/"
+  ProxyPassReverse "/{{ vhost.proxy.path | default(apache_vhost_proxy_path) }}"  "{{ vhost.proxy.host }}/"
+{% endif %}
+{% endif %}
+
 {% if vhost.extra_parameters is defined %}
   {{ vhost.extra_parameters }}
 {% endif %}
@@ -73,6 +91,24 @@
 {% endif %}
   </Directory>
 {% endif %}
+
+{% if vhost.proxy is defined %}
+  {{ "Setup Proxies" | comment }}
+{% if vhost.proxy.members is defined %}
+  <Proxy "balancer://{{ vhost.proxy.balancername | default(apache_vhost_proxy_balancer_name) }}">
+{% for pmember in vhost.proxy.members %}
+    BalancerMember {{ pmember.host }}
+{% endfor %}
+    ProxySet lbmethod={{ vhost.proxy.lbmethod | default(apache_vhost_proxy_lbmethod) }}
+  </Proxy>
+  ProxyPass "/{{ vhost.proxy.path | default(apache_vhost_proxy_path) }}"  "balancer://{{ vhost.proxy.balancername | default(apache_vhost_proxy_balancer_name) }}/"
+  ProxyPassReverse "/{{ vhost.proxy.path | default(apache_vhost_proxy_path) }}"  "balancer://{{ vhost.proxy.balancername | default(apache_vhost_proxy_balancer_name) }}/"
+{% else %}
+  ProxyPass "/{{ vhost.proxy.path | default(apache_vhost_proxy_path) }}"  "{{ vhost.proxy.host }}/"
+  ProxyPassReverse "/{{ vhost.proxy.path | default(apache_vhost_proxy_path) }}"  "{{ vhost.proxy.host }}/"
+{% endif %}
+{% endif %}
+
 {% if vhost.extra_parameters is defined %}
   {{ vhost.extra_parameters }}
 {% endif %}


### PR DESCRIPTION
3.1.4 appears to be the latest tag but master is behind. I've branch from 3.1.4 but can only raise pr back onto master.

This adds basic support for explicit proxy instead of using a blob in extra_parameters. I'm working on setting up a training environment with apache being a proxy in front of weblogic servers. I don't care about proxymembers variable so might play around with a proxy object structure to give more configuration options.