### PR TITLE
Vhost redirectmatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,5 @@ jobs:
         run: >-
           ansible-galaxy role import
            --api-key ${{ secrets.GALAXY_API_KEY }}
-           $(echo $GITHUB_REPOSITORY | cut -d/ -f1)
-           $(echo $GITHUB_REPOSITORY | cut -d/ -f2)
+           $(echo ${{ github.repository }} | cut -d/ -f1)
+           $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,4 @@ jobs:
         run: pip3 install ansible-base
 
       - name: Trigger a new import on Galaxy.
-        run: >-
-          ansible-galaxy role import
-           --api-key ${{ secrets.GALAXY_API_KEY }}
-           $(echo ${{ github.repository }} | cut -d/ -f1)
-           $(echo ${{ github.repository }} | cut -d/ -f2)
+        run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,9 @@
 
 name: Release
 'on':
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - '*'
 
 defaults:
   run:

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -26,6 +26,13 @@
 {% endif %}
   </Directory>
 {% endif %}
+
+{% if vhost.redirectmatches is defined %}
+  {{ "Setup RedirectMatch" | comment }}
+{% for redirectmatch in vhost.redirectmatches %}
+  RedirectMatch "{{ redirectmatch.from }}" "{{ redirectmatch.to }}"
+{% endfor %}{% endif %}
+
 {% if vhost.extra_parameters is defined %}
   {{ vhost.extra_parameters }}
 {% endif %}
@@ -73,6 +80,13 @@
 {% endif %}
   </Directory>
 {% endif %}
+
+{% if vhost.redirectmatches is defined %}
+  {{ "Setup RedirectMatch" | comment }}
+{% for redirectmatch in vhost.redirectmatches %}
+  RedirectMatch "{{ redirectmatch.from }}" "{{ redirectmatch.to }}"
+{% endfor %}{% endif %}
+
 {% if vhost.extra_parameters is defined %}
   {{ vhost.extra_parameters }}
 {% endif %}


### PR DESCRIPTION
3.1.4 appears to be the latest tag but master is behind. I've branch from 3.1.4 but can only raise pr back onto master.

This adds basic support for explicit redirectmatch instead of using a blob in extra_parameters. I'm working on setting up a training environment with apache being a proxy in front of weblogic servers. I don't care about redirectmatches variable so might play around with a proxy object structure to give more configuration options.