### PR TITLE
Add Conditions for Service Handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible-lint
+        run: pip3 install yamllint ansible-lint ansible
 
       - name: Lint code.
         run: |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,13 @@ apache_state: started
 # `restarted` or `reloaded`
 apache_restart_state: restarted
 
+# Set apache service behavior on boot. Recommended values: `true` or `false`
+apache_enabled_on_boot: true
+
+# Set apache service management from ansible. Recommended values: `true` or
+# `false`
+apache_enable_service: true
+
 # Apache package state; use `present` to make sure it's installed, or `latest`
 # if you want to upgrade or switch versions using a new repo.
 apache_packages_state: present

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,4 @@
   service:
     name: "{{ apache_service }}"
     state: "{{ apache_restart_state }}"
+  when: apache_enable_service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,4 +44,5 @@
   service:
     name: "{{ apache_service }}"
     state: "{{ apache_state }}"
-    enabled: true
+    enabled: "{{ apache_enabled_on_boot }}"
+  when: apache_enable_service


### PR DESCRIPTION
This adds variables to manage when to have ansible manage the
apache service. This is similar to the behavior of the php role
when managing php-fpm.

Signed-off-by: David Brown <dmlb2000@gmail.com>