### PR TITLE
Alllow service to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ The list of packages to be installed. This defaults to a set of platform-specifi
 
 Set initial Apache daemon state to be enforced when this role is run. This should generally remain `started`, but you can set it to `stopped` if you need to fix the Apache config during a playbook run or otherwise would not like Apache started at the time this role is run.
 
+    apache_enabled: yes
+
+Set the Apache service boot time status. This should generally remain `yes`, but you can set it to `no` if you need to run Ansible while leaving the service disabled.
+
     apache_packages_state: present
 
 If you have enabled any additional repositories such as _ondrej/apache2_, [geerlingguy.repo-epel](https://github.com/geerlingguy/ansible-role-repo-epel), or [geerlingguy.repo-remi](https://github.com/geerlingguy/ansible-role-repo-remi), you may want an easy way to upgrade versions. You can set this to `latest` (combined with `apache_enablerepo` on RHEL) and can directly upgrade to a different Apache version from a different repo (instead of uninstalling and reinstalling Apache).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,9 @@ apache_mods_disabled: []
 # Set initial apache state. Recommended values: `started` or `stopped`
 apache_state: started
 
+# Set initial apache service status. Recommended values: `yes` or `no`
+apache_enabled: yes
+
 # Set apache state when configuration changes are made. Recommended values:
 # `restarted` or `reloaded`
 apache_restart_state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,4 +44,4 @@
   service:
     name: "{{ apache_service }}"
     state: "{{ apache_state }}"
-    enabled: true
+    enabled: "{{ apache_enabled }}"


### PR DESCRIPTION
In some cases we may need to run this role against servers on which Apache httpd is disabled, or on which we want the initial state of the server to be disabled. This PR adds a variable that can be overridden when setting the enabled/disabled status of the Apache httpd service. The default value is`enabled: yes`, so there is no change to how this role has worked in the past. However, users can set this variable per host as needed.

Further, a `pre_task` can be used with code like the following to keep the current state of the service unchanged. This example assumes that the playbook changes the default values for both `apache_state` and `apache_enabled`, but demonstrates how to re-enable them if the service already existed on the box.

```
- name: Get service status on each host
  service_facts:
  tags: service_status

- set_fact:
    apache_state: "started"
  when:
    - "'httpd.service' in ansible_facts.services"
    - "'running' == ansible_facts.services['httpd.service'].state"
  tags: service_status

- set_fact:
    apache_enabled: "yes"
  when:
    - "'httpd.service' in ansible_facts.services"
    - "'enabled' == ansible_facts.services['httpd.service'].status"
  tags: service_status
```
