### PR TITLE
Removing deprecated TLS versions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,7 +37,7 @@ apache_vhosts_ssl: []
 
 apache_ignore_missing_ssl_certificate: true
 
-apache_ssl_protocol: "All -SSLv2 -SSLv3"
+apache_ssl_protocol: "All -SSLv2 -SSLv3 -TLSv1 -TLSv1.1"
 apache_ssl_cipher_suite: "AES256+EECDH:AES256+EDH"
 
 # Only used on Debian/Ubuntu.


### PR DESCRIPTION
Hi,

As TLS v1 and 1.1 are very soon deprecated, I would like to propose and update for the default value of ssl_protocols.

Regards