### PR TITLE
Allow setting listen port per virtual host.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ apache_global_vhost_settings: |
 
 apache_vhosts:
   # Additional properties:
-  # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
+  # 'serveradmin, serveralias, allow_override, options, extra_parameters, listen_port'.
   - servername: "local.dev"
     documentroot: "/var/www/html"
 
@@ -27,7 +27,7 @@ apache_options: "-Indexes +FollowSymLinks"
 
 apache_vhosts_ssl: []
 # Additional properties:
-# 'serveradmin, serveralias, allow_override, options, extra_parameters'.
+# 'serveradmin, serveralias, allow_override, options, extra_parameters, listen_port'.
 # - servername: "local.dev",
 #   documentroot: "/var/www/html",
 #   certificate_file: "/path/to/certificate.crt",

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -2,7 +2,11 @@
 
 {# Set up VirtualHosts #}
 {% for vhost in apache_vhosts %}
+{% if vhost.listen_port is defined %}
+<VirtualHost {{ apache_listen_ip }}:{{ vhost.listen_port }}>
+{% else %}
 <VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
+{% endif %}
   ServerName {{ vhost.servername }}
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}


### PR DESCRIPTION
Amends vhost template with conditional check for vhost.listen_port
variable.

Updates comments in defaults/main.yaml to reflect new optional variable.