### PR TITLE
add no_log to mask vhost_ssl data from output

### DIFF
--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -29,7 +29,7 @@
   stat: "path={{ item.certificate_file }}"
   register: apache_ssl_certificates
   with_items: "{{ apache_vhosts_ssl }}"
-  no_tag: true
+  no_log: true
 
 - name: Add apache vhosts configuration.
   template:

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -29,6 +29,7 @@
   stat: "path={{ item.certificate_file }}"
   register: apache_ssl_certificates
   with_items: "{{ apache_vhosts_ssl }}"
+  no_tag: true
 
 - name: Add apache vhosts configuration.
   template:

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -13,7 +13,7 @@
   stat: path={{ item.certificate_file }}
   register: apache_ssl_certificates
   with_items: "{{ apache_vhosts_ssl }}"
-  no_tag: true
+  no_log: true
 
 - name: Add apache vhosts configuration.
   template:

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -13,6 +13,7 @@
   stat: path={{ item.certificate_file }}
   register: apache_ssl_certificates
   with_items: "{{ apache_vhosts_ssl }}"
+  no_tag: true
 
 - name: Add apache vhosts configuration.
   template:

--- a/tasks/configure-Suse.yml
+++ b/tasks/configure-Suse.yml
@@ -13,7 +13,7 @@
   stat: path={{ item.certificate_file }}
   register: apache_ssl_certificates
   with_items: "{{ apache_vhosts_ssl }}"
-  no_tag: true
+  no_log: true
 
 - name: Add apache vhosts configuration.
   template:

--- a/tasks/configure-Suse.yml
+++ b/tasks/configure-Suse.yml
@@ -13,6 +13,7 @@
   stat: path={{ item.certificate_file }}
   register: apache_ssl_certificates
   with_items: "{{ apache_vhosts_ssl }}"
+  no_tag: true
 
 - name: Add apache vhosts configuration.
   template:


### PR DESCRIPTION
Adding `no_log: true` to vhosts_ssl tasks to mask output for security purposes