### PR TITLE
Remove default definition for apache_vhosts apache_vhosts_ssl

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,16 +16,16 @@ apache_remove_default_vhost: false
 apache_global_vhost_settings: |
   DirectoryIndex index.php index.html
 
-apache_vhosts:
+#apache_vhosts:
   # Additional properties:
   # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
-  - servername: "local.dev"
-    documentroot: "/var/www/html"
+#  - servername: "local.dev"
+#    documentroot: "/var/www/html"
 
 apache_allow_override: "All"
 apache_options: "-Indexes +FollowSymLinks"
 
-apache_vhosts_ssl: []
+#apache_vhosts_ssl: []
 # Additional properties:
 # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
 # - servername: "local.dev",

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -1,6 +1,7 @@
 {{ apache_global_vhost_settings }}
 
 {# Set up VirtualHosts #}
+{% if apache_vhosts is defined %}
 {% for vhost in apache_vhosts %}
 <VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
   ServerName {{ vhost.servername }}
@@ -32,8 +33,10 @@
 </VirtualHost>
 
 {% endfor %}
+{% endif %}
 
 {# Set up SSL VirtualHosts #}
+{% if apache_vhosts_ssl is defined %}
 {% for vhost in apache_vhosts_ssl %}
 {% if apache_ignore_missing_ssl_certificate or apache_ssl_certificates.results[loop.index0].stat.exists %}
 <VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port_ssl }}>
@@ -80,3 +83,4 @@
 
 {% endif %}
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
Allows you to choose whether you want to create sites in http or only in https