### PR TITLE
fix Debian check mode

### DIFF
--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -46,6 +46,7 @@
     dest: "{{ apache_conf_path }}/sites-enabled/{{ apache_vhosts_filename }}"
     state: link
     mode: 0644
+    force: "{{ ansible_check_mode }}"
   notify: restart apache
   when: apache_create_vhosts | bool
 


### PR DESCRIPTION
Ansible file module needs force attribute if symlink destination doesn't exist which is the case in check mode.