### PR TITLE
Disable SSLHonorCipherOrder

### DIFF
--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -48,7 +48,7 @@
   SSLEngine on
   SSLCipherSuite {{ apache_ssl_cipher_suite }}
   SSLProtocol {{ apache_ssl_protocol }}
-  SSLHonorCipherOrder On
+  SSLHonorCipherOrder off
 {% if apache_vhosts_version == "2.4" %}
   SSLCompression off
 {% endif %}


### PR DESCRIPTION
It's recommended by https://ssl-config.mozilla.org/#server=apache&version=2.4.41&config=modern&openssl=1.1.1k&guideline=5.7 to disable SSLHonorCipherOrder.