### PR TITLE
feat: Allow vhosts to listen on own hosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ apache_global_vhost_settings: |
 
 apache_vhosts:
   # Additional properties:
-  # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
+  # 'serveradmin, serveralias, allow_override, options, extra_parameters, listen_ip, listen_port'.
   - servername: "local.dev"
     documentroot: "/var/www/html"
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,6 +10,10 @@
     apache_vhosts:
       - servername: "example.com"
         documentroot: "/var/www/vhosts/example_com"
+      - servername: "local.example.com"
+        documentroot: "/var/www/vhosts/example_com"
+        listen_ip: 127.0.0.1
+        listen_port: 8080
 
   pre_tasks:
     - name: Update apt cache.

--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -1,8 +1,25 @@
 {{ apache_global_vhost_settings }}
 
 {# Set up VirtualHosts #}
+{% set _extra_listen_list = [] %}
+{% for vhost in (apache_vhosts | selectattr('listen_ip', 'defined') + apache_vhosts | selectattr('listen_port', 'defined')) | unique %}
+{%   set _ = _extra_listen_list.append({
+               'ip': vhost.listen_ip | default(apache_listen_ip),
+               'port': vhost.listen_port | default(apache_listen_port)
+             })
+%}
+{% endfor %}
+{% for listen in _extra_listen_list | unique %}
+{%   if apache_vhosts_version == '2.2' %}
+Listen {{ listen['port'] }}
+NameVirtualHost {{ listen['ip'] }}:{{ listen['port'] }}
+{%   elif apache_vhosts_version == '2.4' %}
+Listen {{ (listen['ip'] == '*') | ternary('', listen['ip'] + ':') }}{{ listen['port'] }}
+{%   endif %}
+{% endfor %}
+
 {% for vhost in apache_vhosts %}
-<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
+<VirtualHost {{ vhost.listen_ip | default(apache_listen_ip) }}:{{ vhost.listen_port | default(apache_listen_port) }}>
   ServerName {{ vhost.servername }}
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}
@@ -36,7 +53,7 @@
 {# Set up SSL VirtualHosts #}
 {% for vhost in apache_vhosts_ssl %}
 {% if apache_ignore_missing_ssl_certificate or apache_ssl_certificates.results[loop.index0].stat.exists %}
-<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port_ssl }}>
+<VirtualHost {{ vhost.listen_ip | default(apache_listen_ip) }}:{{ vhost.listen_port_ssl | default(apache_listen_port_ssl) }}>
   ServerName {{ vhost.servername }}
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}


### PR DESCRIPTION
Current vhosts defenition limit them to listen only on single IP/port.
In the meanwhile, there are usecases where vhosts on the same server
might wanna listen on different quite independent set of IPs/ports,
which is not currently possible.

This patch adds such functionality, and an operator might define
extra properties for apache_vhosts to make them listening on required
ports/interfaces.