### PR TITLE
feat: Adding Debian 12 (bookworm) testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
           - rockylinux9
           - ubuntu2204
           - debian11
+          - debian12
 
     steps:
       - name: Check out the codebase.


### PR DESCRIPTION
Debian 12 has been released on June 29, 2023, so it should be stable
enough at this point to add it to the test matrix.