### PR TITLE
update to prevent INJECT_FACTS_AS_VARS deprecation

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -14,7 +14,7 @@
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
       changed_when: false
 
   roles:

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -45,10 +45,10 @@
   stat:
     path: /etc/pki/tls/certs/localhost.crt
   register: localhost_cert
-  when: ansible_distribution_major_version | int >= 8
+  when: ansible_facts.distribution_major_version | int >= 8
 
 - name: Ensure httpd certs are installed (RHEL 8 and later).
   command: /usr/libexec/httpd-ssl-gencerts
   when:
-    - ansible_distribution_major_version | int >= 8
+    - ansible_facts.distribution_major_version | int >= 8
     - not localhost_cert.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 # Include variables and define needed variables.
 - name: Include OS-specific variables.
-  include_vars: "{{ ansible_os_family }}.yml"
+  include_vars: "{{ ansible_facts.os_family }}.yml"
 
 - name: Include variables for Amazon Linux.
   include_vars: "AmazonLinux.yml"
   when:
-    - ansible_distribution == "Amazon"
-    - ansible_distribution_major_version == "NA"
+    - ansible_facts.distribution == "Amazon"
+    - ansible_facts.distribution_major_version == "NA"
 
 - name: Define apache_packages.
   set_fact:
@@ -15,7 +15,7 @@
   when: apache_packages is not defined
 
 # Setup/install tasks.
-- include_tasks: "setup-{{ ansible_os_family }}.yml"
+- include_tasks: "setup-{{ ansible_facts.os_family }}.yml"
 
 # Figure out what version of Apache is installed.
 - name: Get installed version of Apache.
@@ -38,7 +38,7 @@
 
 # Configure Apache.
 - name: Configure Apache.
-  include_tasks: "configure-{{ ansible_os_family }}.yml"
+  include_tasks: "configure-{{ ansible_facts.os_family }}.yml"
 
 - name: Ensure Apache has selected state and enabled on boot.
   service:


### PR DESCRIPTION
Fixes the deprecation warning below and alike. Usages were replaced accordingly.

```
TASK [geerlingguy.apache : Include OS-specific variables.] *********************
[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
Origin: geerlingguy.apache/tasks/main.yml:4:17

2 # Include variables and define needed variables.
3 - name: Include OS-specific variables.
4   include_vars: "{{ ansible_os_family }}.yml"
                  ^ column 17

Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```